### PR TITLE
Add Node.js, pnpm, and bash support to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,12 +29,33 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@beta
         with:
           # Or use OAuth token instead:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"
+          allowed_tools: |
+            Bash(pnpm install)
+            Bash(pnpm run build)
+            Bash(pnpm run test)
+            Bash(pnpm run check)
+            Bash(pnpm run whoami)
+            Bash(npx am-i-vibing)
           # Optional: Restrict network access to specific domains only
           # experimental_allowed_domains: |
           #   .anthropic.com


### PR DESCRIPTION
## Summary
• Adds Node.js 20 setup with pnpm caching for dependency management
• Installs pnpm version 10.13.1 as specified in package.json
• Installs dependencies with pnpm install before running Claude
• Enables bash command support with proper allowed_tools configuration
• Supports all pnpm commands (build, test, check, whoami) and npx CLI usage

## Test plan
- [ ] Verify Node.js and pnpm setup works correctly
- [ ] Test that pnpm commands are available to Claude
- [ ] Confirm npx am-i-vibing CLI works in the action environment
- [ ] Validate dependency installation completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)