### PR TITLE
feat: Add support for detecting opencode

### DIFF
--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -5,6 +5,22 @@ import type { ProviderConfig } from "./types.js";
  */
 export const providers: ProviderConfig[] = [
   {
+    id: "sst-opencode",
+    name: "SST OpenCode",
+    type: "interactive",
+    envVars: [
+      {
+        any: [
+          "OPENCODE_BIN_PATH",
+          "OPENCODE_SERVER",
+          "OPENCODE_APP_INFO",
+          "OPENCODE_MODES",
+        ],
+      },
+    ],
+    processChecks: ["opencode"],
+  },
+  {
     id: "jules",
     name: "Jules",
     type: "agent",

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -94,6 +94,16 @@ describe("detectAgenticEnvironment", () => {
     expect(result.type).toBe("agent");
   });
 
+  it("should detect SST OpenCode environment", () => {
+    const testEnv = { OPENCODE_BIN_PATH: "/usr/local/bin/opencode" };
+    const result = detectAgenticEnvironment(testEnv);
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("sst-opencode");
+    expect(result.name).toBe("SST OpenCode");
+    expect(result.type).toBe("interactive");
+  });
+
   it("should detect Aider environment", () => {
     const testEnv = { AIDER_API_KEY: "aider-key" };
     const result = detectAgenticEnvironment(testEnv);


### PR DESCRIPTION
Added support for detecting https://github.com/sst/opencode

Tests results:
 RUN  v3.2.4 /workspaces/am-i-vibing/packages/am-i-vibing

 ✓ test/detector.test.ts (21 tests) 3460ms
   ✓ detectAgenticEnvironment > should detect GitHub Copilot Agent environment  310ms
   ✓ detectAgenticEnvironment > should distinguish between Zed agent and interactive variants  385ms
 ✓ test/hello.test.ts (7 tests) 5ms

 Test Files  2 passed (2)
      Tests  28 passed (28)
   Start at  15:57:27
   Duration  4.03s (transform 88ms, setup 0ms, collect 119ms, tests 3.46s, environment 0ms, prepare 175ms)