### PR TITLE
feat: detect Gemini CLI, Codex, Crush via env vars and make process checks opt-in

### DIFF
--- a/.changeset/process-checks-opt-in.md
+++ b/.changeset/process-checks-opt-in.md
@@ -1,0 +1,9 @@
+---
+"am-i-vibing": minor
+---
+
+Add env-var detection for Gemini CLI (`GEMINI_CLI=1`), OpenAI Codex (`CODEX_THREAD_ID`), and Crush (`CRUSH=1`, `AGENT=crush`, `AI_AGENT=crush`). These providers previously relied on process-tree inspection, which was the main reason `am-i-vibing` reached for the process tree at all.
+
+Process-ancestry detection is now opt-in. Reading the process tree spawns a subprocess and is slow on Windows, so by default the library only consults environment variables. Pass `{ checkProcesses: true }` to `detectAgenticEnvironment` (or use the new `--check-processes` CLI flag) to restore the previous behaviour. Octofriend, which exposes no identifying env var, requires this flag.
+
+The detector functions also gain an options-object signature: `detectAgenticEnvironment({ env, processAncestry, checkProcesses })`. The legacy positional signature `(env, processAncestry)` continues to work and is treated as opt-in for process checks for backwards compatibility.

--- a/packages/am-i-vibing/README.md
+++ b/packages/am-i-vibing/README.md
@@ -27,16 +27,18 @@ console.log(`Detected: ${result.name} (${result.type})`);
 - **Aider**
 - **Bolt**
 - **Claude Code**
+- **Codex CLI**
+- **Crush**
 - **Cursor**
 - **Gemini CLI**
 - **GitHub Copilot Agent**
 - **Jules**
-- **Codex CLI**
+- **Octofriend** (process detection only — requires `checkProcesses`)
+- **opencode**
 - **Replit**
 - **Warp**
 - **Windsurf**
 - **Zed**
-- **opencode**
 
 ## Example use case
 
@@ -104,6 +106,36 @@ if (isHybrid()) {
 // Note: Hybrid environments return true for both isAgent() and isInteractive()
 ```
 
+### Process-tree detection (opt-in)
+
+Most providers expose an environment variable that uniquely identifies them, and
+that's the only signal `am-i-vibing` consults by default. A small number (e.g.
+Octofriend) can only be detected by inspecting the parent process chain. Reading
+the process tree spawns a subprocess and is meaningfully slow on Windows, so it
+is **off by default**.
+
+To opt in:
+
+```typescript
+import { detectAgenticEnvironment } from "am-i-vibing";
+
+const result = detectAgenticEnvironment({ checkProcesses: true });
+```
+
+You can also pre-supply an ancestry (e.g. if you are already collecting one):
+
+```typescript
+import { detectAgenticEnvironment } from "am-i-vibing";
+import { getProcessAncestry } from "process-ancestry";
+
+const result = detectAgenticEnvironment({
+  processAncestry: getProcessAncestry(),
+});
+```
+
+Supplying `processAncestry` implies `checkProcesses: true` unless you set it to
+`false` explicitly.
+
 ## Detection Result
 
 The library returns a `DetectionResult` object with the following structure:
@@ -151,7 +183,8 @@ npx am-i-vibing --debug
 - `-f, --format <json|text>` - Output format (default: text)
 - `-c, --check <agent|interactive|hybrid>` - Check for specific environment type
 - `-q, --quiet` - Only output result, no labels
-- `-d, --debug` - Debug output with environment and process info
+- `-p, --check-processes` - Also walk the process tree for detection (slower, off by default)
+- `-d, --debug` - Debug output with environment and process info (implies `--check-processes`)
 - `-h, --help` - Show help message
 
 ### Exit Codes

--- a/packages/am-i-vibing/src/cli.ts
+++ b/packages/am-i-vibing/src/cli.ts
@@ -15,6 +15,7 @@ interface CliOptions {
   quiet?: boolean;
   help?: boolean;
   debug?: boolean;
+  checkProcesses?: boolean;
 }
 
 function parseCliArgs(): CliOptions {
@@ -45,6 +46,11 @@ function parseCliArgs(): CliOptions {
         short: "d",
         default: false,
       },
+      "check-processes": {
+        type: "boolean",
+        short: "p",
+        default: false,
+      },
     },
     allowPositionals: false,
   });
@@ -58,7 +64,10 @@ function parseCliArgs(): CliOptions {
   }
 
   // Validate check option
-  if (values.check && !["agent", "interactive", "hybrid"].includes(values.check)) {
+  if (
+    values.check &&
+    !["agent", "interactive", "hybrid"].includes(values.check)
+  ) {
     console.error(
       `Error: Invalid check type '${values.check}'. Must be 'agent', 'interactive', or 'hybrid'.`,
     );
@@ -71,6 +80,7 @@ function parseCliArgs(): CliOptions {
     quiet: values.quiet,
     help: values.help,
     debug: values.debug,
+    checkProcesses: values["check-processes"],
   };
 }
 
@@ -85,6 +95,8 @@ OPTIONS:
   -f, --format <json|text>     Output format (default: text)
   -c, --check <agent|interactive|hybrid>  Check for specific environment type
   -q, --quiet                  Only output result, no labels
+  -p, --check-processes        Also walk the process tree for detection
+                               (slower, off by default)
   -d, --debug                  Debug output with environment and process info
   -h, --help                   Show this help message
 
@@ -94,6 +106,7 @@ EXAMPLES:
   npx am-i-vibing --check agent      # Check if running under agent
   npx am-i-vibing --check hybrid     # Check if running under hybrid
   npx am-i-vibing --quiet            # Minimal output
+  npx am-i-vibing --check-processes  # Include process-tree detection
   npx am-i-vibing --debug            # Debug with full environment info
 
 EXIT CODES:
@@ -102,14 +115,17 @@ EXIT CODES:
 `);
 }
 
-function checkEnvironmentType(checkType: string): boolean {
+function checkEnvironmentType(
+  checkType: string,
+  options: { checkProcesses?: boolean },
+): boolean {
   switch (checkType) {
     case "agent":
-      return isAgent();
+      return isAgent({ checkProcesses: options.checkProcesses });
     case "interactive":
-      return isInteractive();
+      return isInteractive({ checkProcesses: options.checkProcesses });
     case "hybrid":
-      return isHybrid();
+      return isHybrid({ checkProcesses: options.checkProcesses });
     default:
       return false;
   }
@@ -141,13 +157,13 @@ function formatOutput(
 
   if (options.quiet) {
     if (options.check) {
-      return checkEnvironmentType(options.check) ? "true" : "false";
+      return checkEnvironmentType(options.check, options) ? "true" : "false";
     }
     return result.isAgentic ? `${result.name}` : "none";
   }
 
   if (options.check) {
-    const matches = checkEnvironmentType(options.check);
+    const matches = checkEnvironmentType(options.check, options);
     return matches
       ? `✓ Running in ${options.check} environment: ${result.name}`
       : `✗ Not running in ${options.check} environment`;
@@ -168,11 +184,13 @@ function main(): void {
     process.exit(0);
   }
 
-  const result = detectAgenticEnvironment();
+  // --debug always reveals the full picture, including process detection
+  const checkProcesses = options.checkProcesses || options.debug;
+  const result = detectAgenticEnvironment({ checkProcesses });
   let exitCode = 1;
 
   if (options.check) {
-    exitCode = checkEnvironmentType(options.check) ? 0 : 1;
+    exitCode = checkEnvironmentType(options.check, { checkProcesses }) ? 0 : 1;
   } else {
     exitCode = result.isAgentic ? 0 : 1;
   }

--- a/packages/am-i-vibing/src/detector.ts
+++ b/packages/am-i-vibing/src/detector.ts
@@ -1,5 +1,6 @@
 import type {
   DetectionResult,
+  DetectOptions,
   ProviderConfig,
   EnvVarDefinition,
   EnvVarGroup,
@@ -28,17 +29,12 @@ function checkEnvVar(
  */
 function checkProcess(
   processName: string,
-  processAncestry?: Array<{ command?: string }>,
+  processAncestry: Array<{ command?: string }>,
 ): boolean {
-  try {
-    const ancestry = processAncestry ?? getProcessAncestry();
-    for (const ancestorProcess of ancestry) {
-      if (ancestorProcess.command?.includes(processName)) {
-        return true;
-      }
+  for (const ancestorProcess of processAncestry) {
+    if (ancestorProcess.command?.includes(processName)) {
+      return true;
     }
-  } catch (error) {
-    // Ignore process check errors
   }
   return false;
 }
@@ -99,12 +95,75 @@ function createDetectedResult(provider: ProviderConfig): DetectionResult {
 }
 
 /**
+ * Normalize the various supported argument shapes into a DetectOptions object.
+ *
+ * Supported shapes:
+ *   - detectAgenticEnvironment()
+ *   - detectAgenticEnvironment(options)
+ *   - detectAgenticEnvironment(env)                       // legacy
+ *   - detectAgenticEnvironment(env, processAncestry)      // legacy
+ */
+function normalizeOptions(
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
+): Required<Pick<DetectOptions, "env" | "checkProcesses">> & {
+  processAncestry?: Array<{ command?: string }>;
+} {
+  // Distinguish a DetectOptions object from a raw env record. DetectOptions
+  // has at least one of the known keys; an env record is a flat string map.
+  const looksLikeOptions =
+    envOrOptions != null &&
+    typeof envOrOptions === "object" &&
+    ("env" in envOrOptions ||
+      "processAncestry" in envOrOptions ||
+      "checkProcesses" in envOrOptions);
+
+  if (looksLikeOptions) {
+    const opts = envOrOptions as DetectOptions;
+    return {
+      env: opts.env ?? process.env,
+      processAncestry: opts.processAncestry,
+      // If the caller pre-supplied an ancestry, default checkProcesses to true
+      // unless they explicitly opted out.
+      checkProcesses:
+        opts.checkProcesses ?? opts.processAncestry !== undefined,
+    };
+  }
+
+  return {
+    env:
+      (envOrOptions as Record<string, string | undefined> | undefined) ??
+      process.env,
+    processAncestry: legacyAncestry,
+    // Legacy callers that explicitly passed an ancestry are presumed to want
+    // process checks; otherwise default off.
+    checkProcesses: legacyAncestry !== undefined,
+  };
+}
+
+/**
  * Detect agentic coding environment
  */
 export function detectAgenticEnvironment(
-  env: Record<string, string | undefined> = process.env,
+  options?: DetectOptions,
+): DetectionResult;
+/**
+ * @deprecated Pass an options object instead. This signature is retained for
+ * backwards compatibility and will be removed in a future major release.
+ */
+export function detectAgenticEnvironment(
+  env: Record<string, string | undefined>,
   processAncestry?: Array<{ command?: string }>,
+): DetectionResult;
+export function detectAgenticEnvironment(
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
 ): DetectionResult {
+  const { env, processAncestry, checkProcesses } = normalizeOptions(
+    envOrOptions,
+    legacyAncestry,
+  );
+
   // Fast path: check all environment variables first
   for (const provider of providers) {
     if (provider.envVars?.some((group) => checkEnvVars(group, env))) {
@@ -112,30 +171,36 @@ export function detectAgenticEnvironment(
     }
   }
 
-  // Slow path: check processes only if no env var match found
-  // Lazy evaluation: compute process ancestry only once when needed
-  let cachedAncestry = processAncestry;
-  const getAncestry = () => {
-    if (cachedAncestry === undefined) {
-      try {
-        cachedAncestry = getProcessAncestry();
-      } catch {
-        cachedAncestry = []; // Fallback to empty on error
-      }
-    }
-    return cachedAncestry;
-  };
-
+  // Custom detectors next (cheap, in-process)
   for (const provider of providers) {
-    if (provider.processChecks?.some((processName) => checkProcess(processName, getAncestry()))) {
+    if (runCustomDetectors(provider)) {
       return createDetectedResult(provider);
     }
   }
 
-  // Custom detectors last
-  for (const provider of providers) {
-    if (runCustomDetectors(provider)) {
-      return createDetectedResult(provider);
+  // Slow path: process ancestry checks. Opt-in only because reading the process
+  // tree spawns a subprocess (notably slow on Windows).
+  if (checkProcesses) {
+    let cachedAncestry = processAncestry;
+    const getAncestry = () => {
+      if (cachedAncestry === undefined) {
+        try {
+          cachedAncestry = getProcessAncestry();
+        } catch {
+          cachedAncestry = [];
+        }
+      }
+      return cachedAncestry;
+    };
+
+    for (const provider of providers) {
+      if (
+        provider.processChecks?.some((processName) =>
+          checkProcess(processName, getAncestry()),
+        )
+      ) {
+        return createDetectedResult(provider);
+      }
     }
   }
 
@@ -153,42 +218,90 @@ export function detectAgenticEnvironment(
  */
 export function isProvider(
   providerName: string,
-  env: Record<string, string | undefined> = process.env,
+  options?: DetectOptions,
+): boolean;
+/**
+ * @deprecated Pass an options object instead.
+ */
+export function isProvider(
+  providerName: string,
+  env: Record<string, string | undefined>,
   processAncestry?: Array<{ command?: string }>,
+): boolean;
+export function isProvider(
+  providerName: string,
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
 ): boolean {
-  const result = detectAgenticEnvironment(env, processAncestry);
+  const result = detectAgenticEnvironment(
+    envOrOptions as DetectOptions,
+    legacyAncestry as Array<{ command?: string }> | undefined,
+  );
   return result.name === providerName;
 }
 
 /**
  * Check if currently running in any agent environment
  */
+export function isAgent(options?: DetectOptions): boolean;
+/**
+ * @deprecated Pass an options object instead.
+ */
 export function isAgent(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined>,
   processAncestry?: Array<{ command?: string }>,
+): boolean;
+export function isAgent(
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
 ): boolean {
-  const result = detectAgenticEnvironment(env, processAncestry);
+  const result = detectAgenticEnvironment(
+    envOrOptions as DetectOptions,
+    legacyAncestry as Array<{ command?: string }> | undefined,
+  );
   return result.type === "agent" || result.type === "hybrid";
 }
 
 /**
  * Check if currently running in any interactive AI environment
  */
+export function isInteractive(options?: DetectOptions): boolean;
+/**
+ * @deprecated Pass an options object instead.
+ */
 export function isInteractive(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined>,
   processAncestry?: Array<{ command?: string }>,
+): boolean;
+export function isInteractive(
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
 ): boolean {
-  const result = detectAgenticEnvironment(env, processAncestry);
+  const result = detectAgenticEnvironment(
+    envOrOptions as DetectOptions,
+    legacyAncestry as Array<{ command?: string }> | undefined,
+  );
   return result.type === "interactive" || result.type === "hybrid";
 }
 
 /**
  * Check if currently running in any hybrid AI environment
  */
+export function isHybrid(options?: DetectOptions): boolean;
+/**
+ * @deprecated Pass an options object instead.
+ */
 export function isHybrid(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined>,
   processAncestry?: Array<{ command?: string }>,
+): boolean;
+export function isHybrid(
+  envOrOptions?: Record<string, string | undefined> | DetectOptions,
+  legacyAncestry?: Array<{ command?: string }>,
 ): boolean {
-  const result = detectAgenticEnvironment(env, processAncestry);
+  const result = detectAgenticEnvironment(
+    envOrOptions as DetectOptions,
+    legacyAncestry as Array<{ command?: string }> | undefined,
+  );
   return result.type === "hybrid";
 }

--- a/packages/am-i-vibing/src/index.ts
+++ b/packages/am-i-vibing/src/index.ts
@@ -3,7 +3,14 @@
  */
 
 // Export types
-export type { AgenticType, ProviderConfig, DetectionResult } from "./types.js";
+export type {
+  AgenticType,
+  ProviderConfig,
+  DetectionResult,
+  DetectOptions,
+  EnvVarDefinition,
+  EnvVarGroup,
+} from "./types.js";
 
 // Export providers
 export { providers, getProvider, getProvidersByType } from "./providers.js";
@@ -11,6 +18,7 @@ export { providers, getProvider, getProvidersByType } from "./providers.js";
 // Export detection functions
 export {
   detectAgenticEnvironment,
+  isProvider,
   isAgent,
   isInteractive,
   isHybrid,

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -57,14 +57,20 @@ export const providers: ProviderConfig[] = [
   },
   {
     id: "gemini-agent",
-    name: "Gemini Agent",
+    name: "Gemini CLI",
     type: "agent",
+    // Gemini CLI sets GEMINI_CLI=1 on every shell command and MCP server it spawns.
+    // See: https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/shellExecutionService.ts
+    envVars: [["GEMINI_CLI", "1"]],
     processChecks: ["gemini"],
   },
   {
     id: "codex",
     name: "OpenAI Codex",
     type: "agent",
+    // Codex injects CODEX_THREAD_ID (the session conversation id) into every shell command it runs.
+    // See: https://github.com/openai/codex/blob/main/codex-rs/protocol/src/shell_environment.rs
+    envVars: ["CODEX_THREAD_ID"],
     processChecks: ["codex"],
   },
   {
@@ -156,6 +162,17 @@ export const providers: ProviderConfig[] = [
     id: "crush",
     name: "Crush",
     type: "agent",
+    // Crush sets CRUSH=1 (and AGENT=crush, AI_AGENT=crush) on every shell exec.
+    // See: https://github.com/charmbracelet/crush/blob/main/internal/shell/shell.go
+    envVars: [
+      {
+        any: [
+          ["CRUSH", "1"],
+          ["AGENT", "crush"],
+          ["AI_AGENT", "crush"],
+        ],
+      },
+    ],
     processChecks: ["crush"],
   },
   {
@@ -185,6 +202,8 @@ export const providers: ProviderConfig[] = [
     id: "octofriend",
     name: "Octofriend",
     type: "agent",
+    // Octofriend does not currently expose an environment variable signal, so it
+    // can only be detected via process ancestry (opt-in).
     processChecks: ["octofriend"],
   },
 ];

--- a/packages/am-i-vibing/src/types.ts
+++ b/packages/am-i-vibing/src/types.ts
@@ -38,7 +38,7 @@ export interface ProviderConfig {
   /** Environment variables */
   envVars?: Array<EnvVarGroup | EnvVarDefinition>;
 
-  /** Process names to check for in the process tree */
+  /** Process names to check for in the process tree (only used when checkProcesses is enabled) */
   processChecks?: string[];
 
   /** Custom detection functions for complex logic */
@@ -60,4 +60,32 @@ export interface DetectionResult {
 
   /** Type of agentic environment, if detected */
   type: AgenticType | null;
+}
+
+/**
+ * Options for `detectAgenticEnvironment` and related helpers.
+ */
+export interface DetectOptions {
+  /**
+   * Environment variables to inspect. Defaults to `process.env`.
+   */
+  env?: Record<string, string | undefined>;
+
+  /**
+   * Pre-computed process ancestry (from `process-ancestry` or compatible). When
+   * provided, this is used in place of fetching ancestry at detection time.
+   * Implies `checkProcesses: true` unless explicitly set to `false`.
+   */
+  processAncestry?: Array<{ command?: string }>;
+
+  /**
+   * Whether to fall back to process-ancestry checks when no environment-variable
+   * match is found. Defaults to `false` because fetching the process tree is
+   * expensive on some platforms (notably Windows).
+   *
+   * Set to `true` to enable detection of providers that only expose a
+   * processChecks signal (e.g. Octofriend), at the cost of spawning a
+   * subprocess to read the process tree.
+   */
+  checkProcesses?: boolean;
 }

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   detectAgenticEnvironment,
-  isProvider,
   isAgent,
   isInteractive,
   isHybrid,
@@ -9,8 +8,7 @@ import {
 
 describe("detectAgenticEnvironment", () => {
   it("should return false for non-agentic environment", () => {
-    const env = {};
-    const result = detectAgenticEnvironment(env, []);
+    const result = detectAgenticEnvironment({ env: {} });
     expect(result.isAgentic).toBe(false);
     expect(result.name).toBe(null);
   });
@@ -20,15 +18,14 @@ describe("detectAgenticEnvironment", () => {
       HOME: "/home/jules",
       USER: "swebot",
     };
-    const result = detectAgenticEnvironment(env, []);
+    const result = detectAgenticEnvironment({ env });
     expect(result.isAgentic).toBe(true);
     expect(result.name).toBe("Jules");
     expect(result.id).toBe("jules");
   });
 
   it("should detect Claude Code environment", () => {
-    const testEnv = { CLAUDECODE: "true" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({ env: { CLAUDECODE: "true" } });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("claude-code");
@@ -37,8 +34,9 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Cursor environment", () => {
-    const testEnv = { CURSOR_TRACE_ID: "cursor-trace-123" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: { CURSOR_TRACE_ID: "cursor-trace-123" },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("cursor");
@@ -47,11 +45,12 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect GitHub Copilot Agent environment", () => {
-    const testEnv = {
-      TERM_PROGRAM: "vscode",
-      GIT_PAGER: "cat",
-    };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: {
+        TERM_PROGRAM: "vscode",
+        GIT_PAGER: "cat",
+      },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("vscode-copilot-agent");
@@ -59,24 +58,13 @@ describe("detectAgenticEnvironment", () => {
     expect(result.type).toBe("agent");
   });
 
-  it("should detect GitHub Copilot (interactive) environment", () => {
-    const testEnv = {
-      CURSOR_TRACE_ID: "trace-123",
-    };
-    const result = detectAgenticEnvironment(testEnv, []);
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("cursor");
-    expect(result.name).toBe("Cursor");
-    expect(result.type).toBe("interactive");
-  });
-
   it("should detect Cursor Agent environment", () => {
-    const testEnv = {
-      CURSOR_TRACE_ID: "cursor-trace-123",
-      PAGER: "head -n 10000 | cat",
-    };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: {
+        CURSOR_TRACE_ID: "cursor-trace-123",
+        PAGER: "head -n 10000 | cat",
+      },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("cursor-agent");
@@ -85,8 +73,7 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Replit AI environment", () => {
-    const testEnv = { REPL_ID: "repl-123" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({ env: { REPL_ID: "repl-123" } });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("replit");
@@ -95,8 +82,7 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect OpenCode environment", () => {
-    const testEnv = { OPENCODE: "1" };
-    const result = detectAgenticEnvironment(testEnv);
+    const result = detectAgenticEnvironment({ env: { OPENCODE: "1" } });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("opencode");
@@ -105,8 +91,9 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect OpenCode environment via legacy env vars", () => {
-    const testEnv = { OPENCODE_BIN_PATH: "/usr/local/bin/opencode" };
-    const result = detectAgenticEnvironment(testEnv);
+    const result = detectAgenticEnvironment({
+      env: { OPENCODE_BIN_PATH: "/usr/local/bin/opencode" },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("opencode");
@@ -115,8 +102,9 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Aider environment", () => {
-    const testEnv = { AIDER_API_KEY: "aider-key" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: { AIDER_API_KEY: "aider-key" },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("aider");
@@ -125,11 +113,12 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Bolt.new Agent environment", () => {
-    const testEnv = {
-      SHELL: "/bin/jsh",
-      npm_config_yes: "true",
-    };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: {
+        SHELL: "/bin/jsh",
+        npm_config_yes: "true",
+      },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("bolt-agent");
@@ -138,8 +127,7 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Bolt.new interactive environment", () => {
-    const testEnv = { SHELL: "/bin/jsh" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({ env: { SHELL: "/bin/jsh" } });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("bolt");
@@ -148,11 +136,12 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Zed Agent environment", () => {
-    const testEnv = {
-      TERM_PROGRAM: "zed",
-      PAGER: "cat",
-    };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: {
+        TERM_PROGRAM: "zed",
+        PAGER: "cat",
+      },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("zed-agent");
@@ -161,8 +150,7 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Zed interactive environment", () => {
-    const testEnv = { TERM_PROGRAM: "zed" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({ env: { TERM_PROGRAM: "zed" } });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("zed");
@@ -171,8 +159,9 @@ describe("detectAgenticEnvironment", () => {
   });
 
   it("should detect Warp hybrid environment", () => {
-    const testEnv = { TERM_PROGRAM: "WarpTerminal" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: { TERM_PROGRAM: "WarpTerminal" },
+    });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("warp");
@@ -180,160 +169,216 @@ describe("detectAgenticEnvironment", () => {
     expect(result.type).toBe("hybrid");
   });
 
+  it("should detect Gemini CLI via GEMINI_CLI env var", () => {
+    const result = detectAgenticEnvironment({ env: { GEMINI_CLI: "1" } });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("gemini-agent");
+    expect(result.name).toBe("Gemini CLI");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should not detect Gemini CLI when GEMINI_CLI has the wrong value", () => {
+    // Gemini specifically sets GEMINI_CLI=1; any other value shouldn't match.
+    const result = detectAgenticEnvironment({
+      env: { GEMINI_CLI: "something-else" },
+    });
+    expect(result.isAgentic).toBe(false);
+  });
+
+  it("should detect Codex via CODEX_THREAD_ID env var", () => {
+    const result = detectAgenticEnvironment({
+      env: { CODEX_THREAD_ID: "thread-abc" },
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("codex");
+    expect(result.name).toBe("OpenAI Codex");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should detect Crush via CRUSH=1 env var", () => {
+    const result = detectAgenticEnvironment({ env: { CRUSH: "1" } });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("crush");
+    expect(result.name).toBe("Crush");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should detect Crush via AGENT=crush env var", () => {
+    const result = detectAgenticEnvironment({ env: { AGENT: "crush" } });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("crush");
+  });
+
   it("should handle false positive scenarios", () => {
-    const testEnv = { RANDOM_VARIABLE: "some-value" };
-    const result = detectAgenticEnvironment(testEnv, []);
+    const result = detectAgenticEnvironment({
+      env: { RANDOM_VARIABLE: "some-value" },
+    });
 
     expect(result.isAgentic).toBe(false);
   });
 
   it("should distinguish between agent and interactive variants", () => {
-    // Test that Cursor Agent is detected before regular Cursor
-    const agentEnv = {
-      CURSOR_TRACE_ID: "cursor-trace-123",
-      PAGER: "head -n 10000 | cat",
-    };
-    const result = detectAgenticEnvironment(agentEnv, []);
+    const agentResult = detectAgenticEnvironment({
+      env: {
+        CURSOR_TRACE_ID: "cursor-trace-123",
+        PAGER: "head -n 10000 | cat",
+      },
+    });
 
-    expect(result.id).toBe("cursor-agent");
-    expect(result.name).toBe("Cursor Agent");
-    expect(result.type).toBe("agent");
+    expect(agentResult.id).toBe("cursor-agent");
+    expect(agentResult.name).toBe("Cursor Agent");
+    expect(agentResult.type).toBe("agent");
 
-    // Test regular Cursor
-    const interactiveEnv = { CURSOR_TRACE_ID: "cursor-trace-123" };
-    const result2 = detectAgenticEnvironment(interactiveEnv, []);
+    const interactiveResult = detectAgenticEnvironment({
+      env: { CURSOR_TRACE_ID: "cursor-trace-123" },
+    });
 
-    expect(result2.id).toBe("cursor");
-    expect(result2.name).toBe("Cursor");
-    expect(result2.type).toBe("interactive");
+    expect(interactiveResult.id).toBe("cursor");
+    expect(interactiveResult.name).toBe("Cursor");
+    expect(interactiveResult.type).toBe("interactive");
   });
 
   it("should distinguish between Zed agent and interactive variants", () => {
-    // Test that Zed Agent is detected before regular Zed
-    const agentEnv = {
-      TERM_PROGRAM: "zed",
-      PAGER: "cat",
-    };
-    const result = detectAgenticEnvironment(agentEnv, []);
+    const agentResult = detectAgenticEnvironment({
+      env: {
+        TERM_PROGRAM: "zed",
+        PAGER: "cat",
+      },
+    });
 
-    expect(result.id).toBe("zed-agent");
-    expect(result.name).toBe("Zed Agent");
-    expect(result.type).toBe("agent");
+    expect(agentResult.id).toBe("zed-agent");
+    expect(agentResult.name).toBe("Zed Agent");
+    expect(agentResult.type).toBe("agent");
 
-    // Test regular Zed
-    const interactiveEnv = { TERM_PROGRAM: "zed" };
-    const result2 = detectAgenticEnvironment(interactiveEnv, []);
+    const interactiveResult = detectAgenticEnvironment({
+      env: { TERM_PROGRAM: "zed" },
+    });
 
-    expect(result2.id).toBe("zed");
-    expect(result2.name).toBe("Zed");
-    expect(result2.type).toBe("interactive");
+    expect(interactiveResult.id).toBe("zed");
+    expect(interactiveResult.name).toBe("Zed");
+    expect(interactiveResult.type).toBe("interactive");
+  });
+});
+
+describe("process ancestry detection (opt-in)", () => {
+  it("should NOT consult processChecks by default", () => {
+    // Octofriend is detectable only via processChecks. With checkProcesses
+    // disabled (the default), passing an ancestry that names octofriend should
+    // not yield a match.
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "octofriend-cli" }],
+      checkProcesses: false,
+    });
+    expect(result.isAgentic).toBe(false);
   });
 
-  it("should detect Crush environment", () => {
-    const testEnv = {};
-    const mockProcessAncestry = [
-      { command: "node /Users/matt/.nvm/versions/node/v22.16.0/bin/crush" },
-      {
-        command:
-          "/Users/matt/.nvm/versions/node/v22.16.0/lib/node_modules/@charmland/crush/bin/crush",
-      },
-    ];
-    const result = detectAgenticEnvironment(testEnv, mockProcessAncestry);
+  it("should detect Octofriend when checkProcesses is enabled", () => {
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "octofriend-cli" }],
+      checkProcesses: true,
+    });
 
     expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("crush");
-    expect(result.name).toBe("Crush");
+    expect(result.id).toBe("octofriend");
+    expect(result.name).toBe("Octofriend");
     expect(result.type).toBe("agent");
+  });
+
+  it("should default checkProcesses to true when processAncestry is supplied without an explicit flag", () => {
+    // Convenience: passing ancestry without saying checkProcesses=true is
+    // treated as opt-in, so callers don't have to set both.
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "node /path/to/octofriend" }],
+    });
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("octofriend");
+  });
+
+  it("should still honor an explicit checkProcesses: false even when ancestry is supplied", () => {
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "octofriend" }],
+      checkProcesses: false,
+    });
+    expect(result.isAgentic).toBe(false);
+  });
+
+  it("should prefer env var matches over process ancestry", () => {
+    // Env var match should win even if ancestry would also match a different
+    // provider.
+    const result = detectAgenticEnvironment({
+      env: { CLAUDECODE: "true" },
+      processAncestry: [{ command: "gemini" }, { command: "octofriend" }],
+      checkProcesses: true,
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("claude-code");
+  });
+
+  it("should fall back to process ancestry when env vars don't match", () => {
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "/usr/local/bin/octofriend" }],
+      checkProcesses: true,
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("octofriend");
   });
 });
 
 describe("convenience functions", () => {
   it("isAgent should identify agent environments", () => {
-    const agentEnv = { CLAUDECODE: "true" };
-    expect(isAgent(agentEnv, [])).toBe(true);
-
-    const interactiveEnv = { CURSOR_TRACE_ID: "trace-123" };
-    expect(isAgent(interactiveEnv, [])).toBe(false); // This should be interactive, not agent
-
-    const cursorAgentEnv = {
-      CURSOR_TRACE_ID: "trace-123",
-      PAGER: "head -n 10000 | cat",
-    };
-    expect(isAgent(cursorAgentEnv, [])).toBe(true); // Now it's Cursor Agent
+    expect(isAgent({ env: { CLAUDECODE: "true" } })).toBe(true);
+    expect(isAgent({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(false);
+    expect(
+      isAgent({
+        env: {
+          CURSOR_TRACE_ID: "trace-123",
+          PAGER: "head -n 10000 | cat",
+        },
+      }),
+    ).toBe(true);
   });
 
   it("isInteractive should identify interactive environments", () => {
-    const interactiveEnv = { CURSOR_TRACE_ID: "trace-123" };
-    expect(isInteractive(interactiveEnv, [])).toBe(true);
-
-    const copilotEnv = {
-      CURSOR_TRACE_ID: "trace-123",
-    };
-    expect(isInteractive(copilotEnv, [])).toBe(true);
+    expect(isInteractive({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(true);
   });
 
   it("isHybrid should identify hybrid environments", () => {
-    const hybridEnv = { TERM_PROGRAM: "WarpTerminal" };
-    expect(isHybrid(hybridEnv, [])).toBe(true);
-
-    const agentEnv = { CLAUDECODE: "true" };
-    expect(isHybrid(agentEnv, [])).toBe(false);
-
-    const interactiveEnv = { CURSOR_TRACE_ID: "trace-123" };
-    expect(isHybrid(interactiveEnv, [])).toBe(false);
+    expect(isHybrid({ env: { TERM_PROGRAM: "WarpTerminal" } })).toBe(true);
+    expect(isHybrid({ env: { CLAUDECODE: "true" } })).toBe(false);
+    expect(isHybrid({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(false);
   });
 });
 
-describe("performance optimizations", () => {
-  it("should prioritize environment variables over process checks", () => {
-    // Mock an environment that matches via env vars
-    const envWithClaudeCode = { CLAUDECODE: "true" };
-    
-    // Mock process ancestry that would match other providers if checked
-    const mockProcessAncestry = [
-      { command: "gemini" },
-      { command: "aider" },
-      { command: "crush" }
-    ];
-    
-    // This should detect Claude Code via env vars without needing process checks
-    const result = detectAgenticEnvironment(envWithClaudeCode, mockProcessAncestry);
-    
-    expect(result.isAgentic).toBe(true);
+describe("legacy positional API (deprecated)", () => {
+  // These call shapes are kept working for backwards compatibility with
+  // callers from before the options-object signature landed.
+  it("should accept (env) positional", () => {
+    const result = detectAgenticEnvironment({ CLAUDECODE: "true" } as any);
     expect(result.id).toBe("claude-code");
-    expect(result.name).toBe("Claude Code");
-    expect(result.type).toBe("agent");
   });
 
-  it("should use process checks only when env vars fail", () => {
-    // Mock an environment with no matching env vars
-    const emptyEnv = {};
-    
-    // Mock process ancestry that matches a provider
-    const mockProcessAncestry = [
-      { command: "node /path/to/crush" }
-    ];
-    
-    const result = detectAgenticEnvironment(emptyEnv, mockProcessAncestry);
-    
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("crush");
-    expect(result.name).toBe("Crush");
-    expect(result.type).toBe("agent");
-  });
-
-  it("should handle process ancestry caching properly", () => {
-    // Test that providing processAncestry parameter works correctly
-    const emptyEnv = {};
-    const mockProcessAncestry = [
-      { command: "octofriend-cli" }
-    ];
-    
-    const result = detectAgenticEnvironment(emptyEnv, mockProcessAncestry);
-    
-    expect(result.isAgentic).toBe(true);
+  it("should accept (env, processAncestry) positional and treat ancestry as opt-in", () => {
+    const result = detectAgenticEnvironment(
+      {} as any,
+      [{ command: "octofriend" }],
+    );
     expect(result.id).toBe("octofriend");
-    expect(result.name).toBe("Octofriend");
-    expect(result.type).toBe("agent");
+  });
+
+  it("should not consult processAncestry under the legacy (env) one-arg form", () => {
+    // No second arg means no opt-in; ancestry isn't consulted.
+    const result = detectAgenticEnvironment({} as any);
+    expect(result.isAgentic).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add env var detection for **Gemini CLI** (`GEMINI_CLI=1`), **OpenAI Codex** (`CODEX_THREAD_ID`), and **Crush** (`CRUSH=1`, `AGENT=crush`, `AI_AGENT=crush`). These three providers used to require process-tree inspection; now they fall through the fast path like Claude Code et al.
- Make process-ancestry checks **opt-in**, off by default. Reading the process tree spawns a subprocess (notably slow on Windows where it walks `wmic` once per ancestor). Pass `{ checkProcesses: true }` or use the new `--check-processes` / `-p` CLI flag to restore the previous behaviour.
- Octofriend still has no env-var signal upstream, so it remains process-only and now requires the opt-in.

## API

New options-object signature:

```ts
detectAgenticEnvironment({ env, processAncestry, checkProcesses });
```

The legacy positional signature `(env, processAncestry)` continues to work and is treated as opt-in for process checks for backwards compatibility. Same shape for `isAgent`/`isInteractive`/`isHybrid`/`isProvider`.

If `processAncestry` is supplied, `checkProcesses` defaults to `true` (you presumably wanted those checks), unless you pass it explicitly as `false`.

## Sources for the new env vars

- Gemini CLI: [`shellExecutionService.ts`](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/services/shellExecutionService.ts) sets `GEMINI_CLI=1` on every shell command and stdio MCP server.
- Codex: [`shell_environment.rs`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/shell_environment.rs) injects `CODEX_THREAD_ID` (the session conversation id) into every command the agent runs.
- Crush: [`shell.go`](https://github.com/charmbracelet/crush/blob/main/internal/shell/shell.go) sets `CRUSH=1`, `AGENT=crush`, and `AI_AGENT=crush` with an explicit "Allow tools to detect execution by Crush" comment.

## Why opt-in

The dominant cost of detection on Windows comes from `process-ancestry` issuing one `wmic` invocation per ancestor (and `wmic` is itself slow / deprecated). With env vars now covering every provider except Octofriend, the default detection path no longer needs to touch the process tree at all.

A separate PR will land in `process-ancestry` to make the Windows path use a single PowerShell snapshot, but this PR alone removes the Windows perf hit for the vast majority of users.

## Tests

42 tests passing. New cases cover:

- Gemini CLI / Codex / Crush env-var detection (including value-validation for `GEMINI_CLI`, which must equal `1`).
- `checkProcesses: false` ignoring a supplied ancestry.
- `processAncestry` supplied without `checkProcesses` defaulting to opt-in.
- Explicit `checkProcesses: false` overriding a supplied ancestry.
- The legacy positional API.

## Changeset

Minor bump (new functionality + soft API addition).