### PR TITLE
feat: detect Amp, Auggie, Qwen Code via env vars; Devin and Droid via process checks

### DIFF
--- a/.changeset/detect-amp-auggie-qwen-devin-droid.md
+++ b/.changeset/detect-amp-auggie-qwen-devin-droid.md
@@ -1,0 +1,18 @@
+---
+"am-i-vibing": minor
+---
+
+Add detection for five more agentic coding tools.
+
+Env-var detection (works by default):
+
+- **Sourcegraph Amp** (`AMP_CURRENT_THREAD_ID`, or `AGENT=amp`)
+- **Auggie** from Augment Code (`AUGMENT_AGENT=1`)
+- **Qwen Code** (`QWEN_CODE=1`)
+
+Process-ancestry detection (opt-in via `checkProcesses: true`):
+
+- **Devin** for Terminal (Cognition) -- `devin` binary in process tree
+- **Factory Droid** -- `droid` binary in process tree
+
+Devin and Droid only inject identifying env vars inside hook commands, not on regular shell tool exec, so process ancestry is the only available signal.

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -176,6 +176,36 @@ export const providers: ProviderConfig[] = [
     processChecks: ["crush"],
   },
   {
+    id: "amp",
+    name: "Amp",
+    type: "agent",
+    // Sourcegraph Amp injects AGENT=amp, AGENT_THREAD_ID, and AMP_CURRENT_THREAD_ID
+    // into every shell tool execution.
+    // See: https://www.npmjs.com/package/@sourcegraph/amp
+    envVars: [
+      {
+        any: ["AMP_CURRENT_THREAD_ID", ["AGENT", "amp"]],
+      },
+    ],
+  },
+  {
+    id: "auggie",
+    name: "Auggie",
+    type: "agent",
+    // Augment Code's Auggie CLI sets AUGMENT_AGENT=1 in the shell tool's env on
+    // every command execution.
+    // See: https://www.npmjs.com/package/@augmentcode/auggie
+    envVars: [["AUGMENT_AGENT", "1"]],
+  },
+  {
+    id: "qwen-code",
+    name: "Qwen Code",
+    type: "agent",
+    // Qwen Code (Alibaba's gemini-cli fork) sets QWEN_CODE=1 on every shell exec.
+    // See: https://www.npmjs.com/package/@qwen-code/qwen-code
+    envVars: [["QWEN_CODE", "1"]],
+  },
+  {
     id: "vscode-copilot-agent",
     name: "GitHub Copilot in VS Code",
     type: "agent",
@@ -205,6 +235,26 @@ export const providers: ProviderConfig[] = [
     // Octofriend does not currently expose an environment variable signal, so it
     // can only be detected via process ancestry (opt-in).
     processChecks: ["octofriend"],
+  },
+  {
+    id: "devin",
+    name: "Devin",
+    type: "agent",
+    // Devin for Terminal does not inject any DEVIN_* env var into shell tool
+    // executions (DEVIN_PROJECT_DIR is only set inside hook commands, and
+    // DEVIN_SESSION_ID/DEVIN_WRAPPER_ACTIVE only exist in the opt-in `devin shell`
+    // integration where the user runs commands themselves). Process ancestry is
+    // the only available signal, so detection is opt-in via processAncestry.
+    processChecks: ["devin"],
+  },
+  {
+    id: "droid",
+    name: "Factory Droid",
+    type: "agent",
+    // Factory's Droid CLI sets DROID_PROJECT_DIR / FACTORY_PROJECT_DIR only inside
+    // hook command invocations, not on regular shell tool exec. Process ancestry
+    // is the only reliable signal, so detection is opt-in via processAncestry.
+    processChecks: ["droid"],
   },
 ];
 

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -213,6 +213,54 @@ describe("detectAgenticEnvironment", () => {
     expect(result.id).toBe("crush");
   });
 
+  it("should detect Amp via AMP_CURRENT_THREAD_ID env var", () => {
+    const result = detectAgenticEnvironment({
+      env: { AMP_CURRENT_THREAD_ID: "T-abc123" },
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("amp");
+    expect(result.name).toBe("Amp");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should detect Amp via AGENT=amp env var", () => {
+    const result = detectAgenticEnvironment({ env: { AGENT: "amp" } });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("amp");
+  });
+
+  it("should detect Auggie via AUGMENT_AGENT=1 env var", () => {
+    const result = detectAgenticEnvironment({
+      env: { AUGMENT_AGENT: "1" },
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("auggie");
+    expect(result.name).toBe("Auggie");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should not detect Auggie when AUGMENT_AGENT has the wrong value", () => {
+    const result = detectAgenticEnvironment({
+      env: { AUGMENT_AGENT: "0" },
+    });
+
+    expect(result.isAgentic).toBe(false);
+  });
+
+  it("should detect Qwen Code via QWEN_CODE=1 env var", () => {
+    const result = detectAgenticEnvironment({
+      env: { QWEN_CODE: "1" },
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("qwen-code");
+    expect(result.name).toBe("Qwen Code");
+    expect(result.type).toBe("agent");
+  });
+
   it("should handle false positive scenarios", () => {
     const result = detectAgenticEnvironment({
       env: { RANDOM_VARIABLE: "some-value" },
@@ -287,6 +335,32 @@ describe("process ancestry detection (opt-in)", () => {
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("octofriend");
     expect(result.name).toBe("Octofriend");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should detect Devin via process ancestry when checkProcesses is enabled", () => {
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "/Users/me/.local/bin/devin" }],
+      checkProcesses: true,
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("devin");
+    expect(result.name).toBe("Devin");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should detect Factory Droid via process ancestry when checkProcesses is enabled", () => {
+    const result = detectAgenticEnvironment({
+      env: {},
+      processAncestry: [{ command: "/usr/local/bin/droid" }],
+      checkProcesses: true,
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("droid");
+    expect(result.name).toBe("Factory Droid");
     expect(result.type).toBe("agent");
   });
 


### PR DESCRIPTION
## Summary

Adds detection for five more agentic coding tools.

**Env-var detection (works by default):**
- **Sourcegraph Amp** -- `AMP_CURRENT_THREAD_ID`, or `AGENT=amp`
- **Auggie** (Augment Code) -- `AUGMENT_AGENT=1`
- **Qwen Code** -- `QWEN_CODE=1`

**Process-ancestry detection (opt-in via `checkProcesses: true`):**
- **Devin for Terminal** (Cognition) -- `devin` in process tree
- **Factory Droid** -- `droid` in process tree

## Why these two patterns

Amp, Auggie, and Qwen Code all inject identifying env vars into every shell tool exec (verified by reading their bundled binaries). Detection is reliable and zero-cost.

Devin and Droid only inject `*_PROJECT_DIR` style env vars inside hook command contexts, not on regular shell tool exec. Process ancestry is the only reliable signal, so they're added alongside Octofriend as opt-in.

## Notes

- Cline, Kilo, and Goose were also evaluated; none currently inject a shell-exec env signal. Could be added as opt-in process checks later if there's demand.
- 49 tests passing, build clean, types pass `arethetypeswrong`.