### PR TITLE
feat: split detection into agent and environment

### DIFF
--- a/.changeset/agent-environment-split.md
+++ b/.changeset/agent-environment-split.md
@@ -1,0 +1,20 @@
+---
+"am-i-vibing": minor
+---
+
+Split detection into agent and environment halves, exposing version, session, container, and run identifiers where available.
+
+`DetectionResult` now returns `agent: AgentInfo | null` and `environment: EnvironmentInfo | null` as independent objects rather than a single flat shape. `isAgentic` is determined by `agent !== null`; the environment is detected separately and may be populated even when no AI agent is driving the process (for example, a CI runner with no agent).
+
+New fields:
+
+- `agent.version` — populated for Claude Code via `CLAUDE_CODE_VERSION`.
+- `agent.sessionId` — populated for Claude Code (`CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_REMOTE_SESSION_ID`), Codex (`CODEX_THREAD_ID`), and Cursor (`CURSOR_TRACE_ID`).
+- `environment.containerId` — populated for Claude Code Cloud, GitHub Actions, Buildkite, and Replit.
+- `environment.runId` — populated for GitHub Actions, GitLab CI, CircleCI, and Buildkite.
+
+New environment matchers: Claude Code Cloud, GitHub Actions, GitLab CI, CircleCI, Buildkite, Replit, Jules, WebContainer, VS Code, Cursor (as IDE), Zed (as IDE).
+
+New exports: `detectAgent`, `detectEnvironment`, `environments`, `getEnvironment`, `getEnvironmentsByKind`, plus the `AgentInfo`, `EnvironmentInfo`, `EnvironmentKind`, `EnvironmentConfig`, and `EnvVarExtractor` types.
+
+**Breaking change**: top-level `id`, `name`, and `type` fields on the detection result are now nested under `agent`. Migrate from `result.id` / `result.name` / `result.type` to `result.agent?.id` / `result.agent?.name` / `result.agent?.type`. The `--format json` CLI output changes shape accordingly. The exit-code contract for the CLI is unchanged (0 if an agent is detected).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,11 +70,14 @@ pnpm run prepublishOnly
 
 ### Library Architecture (am-i-vibing)
 
-- **Core Detection**: `src/detector.ts` - Main detection logic with simplified implementation
-- **Provider Definitions**: `src/providers.ts` - Configuration for each AI tool
+- **Core Detection**: `src/detector.ts` - Composes agent and environment passes into a single result
+- **Provider Definitions**: `src/providers.ts` - Configuration for each AI agent
+- **Environment Definitions**: `src/environments.ts` - Configuration for cloud sandboxes, CI runners, IDEs, WebContainers
 - **Type System**: `src/types.ts` - TypeScript interfaces and types
 - **CLI Interface**: `src/cli.ts` - Command-line interface for npx execution
 - **Public API**: `src/index.ts` - Exports for library consumers
+
+The detector runs two independent passes — one over `providers` (which AI is driving the process) and one over `environments` (where the process is running). The composed `DetectionResult` exposes both halves; either can be `null` independently.
 
 ### Detection Methods
 
@@ -82,14 +85,16 @@ pnpm run prepublishOnly
 2. **Process Tree Analysis**: Using process-ancestry to check running processes
 3. **Custom Detectors**: Functions for complex filesystem or configuration checks
 4. **Logical Operators**: ANY/ALL/NONE conditions for sophisticated detection rules
+5. **Declarative Extractors**: `versionEnvVar`, `sessionIdEnvVar`, `containerIdEnvVar`, `runIdEnvVar` accept `string | string[]`; the first non-empty value wins
 
 ### Key Features
 
 - **Provider Detection**: Supports 10+ major AI coding tools
+- **Environment Detection**: Cloud sandboxes (Claude Code Cloud, Replit, Jules), CI runners (GitHub Actions, GitLab CI, CircleCI, Buildkite), IDEs (VS Code, Cursor, Zed), WebContainer
 - **Detection Categories**: Direct agents, embedded IDE features, hybrid tools
 - **CLI Tool**: Available via `npx am-i-vibing` with multiple output formats
 - **Tuple Detection**: Validates both environment variable names AND expected values
-- **Simple API**: Clean detection results with `id`, `name`, `type`, and `isAgentic`
+- **Nested API**: `agent` and `environment` returned as separate, optional objects with version, sessionId, containerId, and runId where available
 
 ## Supported AI Tools
 
@@ -122,17 +127,24 @@ pnpm run prepublishOnly
 ```bash
 # Basic detection
 npx am-i-vibing
-# ✓ Detected: [claude-code] Claude Code (agent)
+# ✓ Agent: [claude-code] Claude Code (agent) v2.1.42
+#     sessionId: cse_01abc
+#   Environment: [claude-code-cloud] Claude Code Cloud (cloud-sandbox)
+#     containerId: container_xyz
 
-# JSON output
+# JSON output (nested shape)
 npx am-i-vibing --format json
-# {"isAgentic": true, "id": "claude-code", "name": "Claude Code", "type": "agent"}
+# { "isAgentic": true,
+#   "agent": { "id": "claude-code", "name": "Claude Code", "type": "agent",
+#              "version": "2.1.42", "sessionId": "cse_01abc" },
+#   "environment": { "id": "claude-code-cloud", "kind": "cloud-sandbox",
+#                    "containerId": "container_xyz" } }
 
-# Check specific environment type
+# Check specific environment type (still operates on agent type)
 npx am-i-vibing --check agent
 # ✓ Running in agent environment: Claude Code
 
-# Quiet mode (useful for scripts)
+# Quiet mode (useful for scripts) — outputs the agent name or "none"
 npx am-i-vibing --quiet
 # Claude Code
 
@@ -147,23 +159,36 @@ npx am-i-vibing --help
 ### Library Usage
 
 ```typescript
-import { detectAgenticEnvironment, isAgent, isInteractive } from "am-i-vibing";
+import {
+  detectAgenticEnvironment,
+  detectAgent,
+  detectEnvironment,
+  isAgent,
+  isInteractive,
+} from "am-i-vibing";
 
-// Full detection
-const result = detectAgenticEnvironment();
-if (result.isAgentic) {
-  console.log(`Detected: ${result.name} (${result.type})`);
-  console.log(`ID: ${result.id}`);
+// Full detection — returns both halves
+const { agent, environment } = detectAgenticEnvironment();
+
+if (agent) {
+  console.log(`Agent: ${agent.name} (${agent.type})`);
+  if (agent.version) console.log(`Version: ${agent.version}`);
+  if (agent.sessionId) console.log(`Session: ${agent.sessionId}`);
 }
 
-// Quick type checks
-if (isAgent()) {
-  console.log("Running under direct AI agent control");
+if (environment) {
+  console.log(`Environment: ${environment.name} (${environment.kind})`);
+  if (environment.containerId) console.log(`Container: ${environment.containerId}`);
+  if (environment.runId) console.log(`Run: ${environment.runId}`);
 }
 
-if (isInteractive()) {
-  console.log("Running in interactive AI environment");
-}
+// Detect just one half
+const agentOnly = detectAgent();
+const envOnly = detectEnvironment();
+
+// Quick type checks (operate on agent only)
+if (isAgent()) console.log("Running under direct AI agent control");
+if (isInteractive()) console.log("Running in interactive AI environment");
 ```
 
 ## Development Guidelines
@@ -175,6 +200,11 @@ if (isInteractive()) {
 3. Prefer environment variables over custom detectors
 4. Use tuples for value-specific detection
 5. Only use custom detectors for filesystem/process checks
+6. Annotate `versionEnvVar` and `sessionIdEnvVar` when the agent exposes them — pass an array if there's a fallback chain
+
+### Adding New Environments
+
+Environments live in `src/environments.ts` and follow the same matcher shape as providers (`envVars`, `processChecks`, `customDetectors`), plus declarative extractors `containerIdEnvVar` and `runIdEnvVar`. An environment matches a runtime sandbox/CI/IDE rather than an AI agent — these are detected independently and both can fire for the same process.
 
 ### Testing Strategy
 
@@ -242,14 +272,15 @@ Three GitHub Actions workflows:
 ```
 packages/am-i-vibing/
 ├── src/
-│   ├── types.ts      # TypeScript interfaces
-│   ├── providers.ts  # Provider configurations
-│   ├── detector.ts   # Core detection logic
-│   ├── index.ts      # Public API exports
-│   └── cli.ts        # CLI interface
-├── test/             # Test suite
-├── dist/             # Built output (gitignored)
-└── package.json      # Package configuration
+│   ├── types.ts          # TypeScript interfaces
+│   ├── providers.ts      # AI agent configurations
+│   ├── environments.ts   # Runtime environment configurations
+│   ├── detector.ts       # Core detection logic (composes both passes)
+│   ├── index.ts          # Public API exports
+│   └── cli.ts            # CLI interface
+├── test/                 # Test suite
+├── dist/                 # Built output (gitignored)
+└── package.json          # Package configuration
 ```
 
 ## Project Memories

--- a/packages/am-i-vibing/README.md
+++ b/packages/am-i-vibing/README.md
@@ -1,6 +1,6 @@
 # am-i-vibing
 
-Detect agentic coding environments and AI assistant tools. This library allows CLI tools and Node apps to detect when they're being executed by AI agents. This enables them to adapt by, for example, providing different output formats or logs.
+Detect agentic coding environments and AI assistant tools. This library lets CLI tools and Node apps detect when they're being executed by an AI agent — and now also which runtime environment they're running in (cloud sandbox, CI runner, IDE, WebContainer). Tools can adapt by emitting different output formats, choosing different log destinations, or attributing usage.
 
 ## Installation
 
@@ -18,8 +18,9 @@ npx am-i-vibing
 
 ```ts
 import { detectAgenticEnvironment } from "am-i-vibing";
-const result = detectAgenticEnvironment();
-console.log(`Detected: ${result.name} (${result.type})`);
+const { agent, environment } = detectAgenticEnvironment();
+if (agent) console.log(`Agent: ${agent.name} (${agent.type})`);
+if (environment) console.log(`Environment: ${environment.name} (${environment.kind})`);
 ```
 
 ## Supported AI Tools
@@ -39,6 +40,15 @@ console.log(`Detected: ${result.name} (${result.type})`);
 - **Warp**
 - **Windsurf**
 - **Zed**
+
+## Supported Environments
+
+The library also detects the runtime environment a process is executing in, independently of which agent (if any) is driving it:
+
+- **Cloud sandboxes**: Claude Code Cloud, Replit, Jules
+- **CI runners**: GitHub Actions, GitLab CI, CircleCI, Buildkite
+- **IDEs**: Visual Studio Code, Cursor, Zed
+- **WebContainer**: StackBlitz / Bolt.new
 
 ## Example use case
 
@@ -64,46 +74,53 @@ prompt the user to enable the MCP server followng the instructions at https://ex
 }
 ```
 
-## Environment Types
+## Agent Types
 
-The library detects three main types of environments:
+The library classifies agents into three types:
 
 - **Agent**: Command was directly run by an AI agent (e.g. Claude Code, Codex CLI, Jules)
 - **Interactive**: Interactive commands run inside an AI environment (e.g. Cursor terminal, Replit shell)
 - **Hybrid**: Environments that combine both agentic and interactive features in the same session (e.g. Warp)
 
-There may be false positives, such as if a user directly runs a command in an terminal opened by an AI tool, such as a Copilot terminal in VS Code.
+There may be false positives, such as if a user directly runs a command in a terminal opened by an AI tool, such as a Copilot terminal in VS Code.
 
 ## Library Usage
+
+We recommend **destructuring** the fields you use rather than passing the whole result object around. New top-level fields may be added in future versions; destructuring keeps your code forward-compatible with those additions.
 
 ```typescript
 import {
   detectAgenticEnvironment,
+  detectAgent,
+  detectEnvironment,
   isAgent,
   isInteractive,
   isHybrid,
 } from "am-i-vibing";
 
-// Full detection
-const result = detectAgenticEnvironment();
-console.log(`Detected: ${result.name} (${result.type})`);
-console.log(`ID: ${result.id}`);
-console.log(`Is agentic: ${result.isAgentic}`);
+// Full detection (returns both agent and environment)
+const { isAgentic, agent, environment } = detectAgenticEnvironment();
 
-// Quick checks
-if (isAgent()) {
-  console.log("Running under direct AI agent control");
+if (agent) {
+  console.log(`Agent: ${agent.name} (${agent.type})`);
+  if (agent.version) console.log(`Version: ${agent.version}`);
+  if (agent.sessionId) console.log(`Session: ${agent.sessionId}`);
 }
 
-if (isInteractive()) {
-  console.log("Running in interactive AI environment");
+if (environment) {
+  console.log(`Environment: ${environment.name} (${environment.kind})`);
+  if (environment.containerId) console.log(`Container: ${environment.containerId}`);
+  if (environment.runId) console.log(`Run: ${environment.runId}`);
 }
 
-if (isHybrid()) {
-  console.log("Running in hybrid AI environment");
-}
+// Detect just one half
+const agentInfo = detectAgent();
+const envInfo = detectEnvironment();
 
-// Note: Hybrid environments return true for both isAgent() and isInteractive()
+// Quick boolean checks
+if (isAgent()) console.log("Running under direct AI agent control");
+if (isInteractive()) console.log("Running in interactive AI environment");
+if (isHybrid()) console.log("Running in hybrid AI environment");
 ```
 
 ### Process-tree detection (opt-in)
@@ -138,16 +155,56 @@ Supplying `processAncestry` implies `checkProcesses: true` unless you set it to
 
 ## Detection Result
 
-The library returns a `DetectionResult` object with the following structure:
+The library returns a `DetectionResult` with two independent halves:
 
 ```typescript
 interface DetectionResult {
-  isAgentic: boolean; // Whether any agentic environment was detected
-  id: string | null; // Provider ID (e.g., "claude-code")
-  name: string | null; // Human-readable name (e.g., "Claude Code")
-  type: AgenticType | null; // "agent" | "interactive" | "hybrid"
+  isAgentic: boolean;            // True iff agent !== null
+  agent: AgentInfo | null;       // The AI agent driving the process
+  environment: EnvironmentInfo | null; // The runtime sandbox / CI / IDE
+}
+
+interface AgentInfo {
+  id: string;                    // e.g. "claude-code"
+  name: string;                  // e.g. "Claude Code"
+  type: "agent" | "interactive" | "hybrid";
+  version?: string;              // Reported version, if available
+  sessionId?: string;            // Conversation/thread id, if available
+}
+
+interface EnvironmentInfo {
+  id: string;                    // e.g. "github-actions"
+  name: string;                  // e.g. "GitHub Actions"
+  kind: "cloud-sandbox" | "ci-runner" | "ide" | "webcontainer";
+  containerId?: string;          // Stable per sandbox/runner
+  runId?: string;                // Stable per execution
 }
 ```
+
+`agent` and `environment` are populated independently. A CI job running with no AI agent driving it returns `agent: null, environment: { kind: "ci-runner", ... }`. A Claude Code session on a developer's laptop returns the agent populated and `environment: null`. Claude Code running in GitHub Actions populates both.
+
+`null` for `environment` means "no recognised environment fingerprint" rather than "this is a local laptop" — we know what it isn't, not what it is.
+
+### What gets populated where
+
+| Agent | `version` | `sessionId` |
+|---|---|---|
+| Claude Code | `CLAUDE_CODE_VERSION` | `CLAUDE_CODE_SESSION_ID` ‖ `CLAUDE_CODE_REMOTE_SESSION_ID` |
+| Codex CLI | – | `CODEX_THREAD_ID` |
+| Cursor / Cursor Agent | – | `CURSOR_TRACE_ID` |
+| (others) | – | – |
+
+| Environment | `containerId` | `runId` |
+|---|---|---|
+| Claude Code Cloud | `CLAUDE_CODE_CONTAINER_ID` | – |
+| GitHub Actions | `RUNNER_NAME` | `GITHUB_RUN_ID` |
+| GitLab CI | – | `CI_JOB_ID` |
+| CircleCI | – | `CIRCLE_BUILD_NUM` |
+| Buildkite | `BUILDKITE_AGENT_NAME` | `BUILDKITE_BUILD_ID` |
+| Replit | `REPL_ID` | – |
+| Jules | – | – |
+| WebContainer | – | – |
+| VS Code / Cursor / Zed | – | – |
 
 ## CLI Usage
 
@@ -156,11 +213,20 @@ Use the CLI to quickly check if you're running in an agentic environment:
 ```bash
 # Basic detection
 npx am-i-vibing
-# ✓ Detected: Claude Code (agent)
+# ✓ Agent: [claude-code] Claude Code (agent) v2.1.42
+#     sessionId: cse_01abc
+#   Environment: [claude-code-cloud] Claude Code Cloud (cloud-sandbox)
+#     containerId: container_xyz
 
-# JSON output
+# JSON output (full nested shape)
 npx am-i-vibing --format json
-# {"isAgentic": true, "id": "claude-code", "name": "Claude Code", "type": "agent"}
+# {
+#   "isAgentic": true,
+#   "agent": { "id": "claude-code", "name": "Claude Code", "type": "agent",
+#              "version": "2.1.42", "sessionId": "cse_01abc" },
+#   "environment": { "id": "claude-code-cloud", "name": "Claude Code Cloud",
+#                    "kind": "cloud-sandbox", "containerId": "container_xyz" }
+# }
 
 # Check for specific environment type
 npx am-i-vibing --check agent
@@ -169,19 +235,18 @@ npx am-i-vibing --check agent
 npx am-i-vibing --check interactive
 # ✗ Not running in interactive environment
 
-# Quiet mode (useful for scripts)
+# Quiet mode (useful for scripts) — outputs the agent name or "none"
 npx am-i-vibing --quiet
 # Claude Code
 
 # Debug mode (full diagnostic output)
 npx am-i-vibing --debug
-# {"detection": {"isAgentic": true, "id": "claude-code", "name": "Claude Code", "type": "agent"}, "environment": {...}, "processAncestry": [...]}
 ```
 
 ### CLI Options
 
 - `-f, --format <json|text>` - Output format (default: text)
-- `-c, --check <agent|interactive|hybrid>` - Check for specific environment type
+- `-c, --check <agent|interactive|hybrid>` - Check for specific agent type
 - `-q, --quiet` - Only output result, no labels
 - `-p, --check-processes` - Also walk the process tree for detection (slower, off by default)
 - `-d, --debug` - Debug output with environment and process info (implies `--check-processes`)
@@ -189,8 +254,10 @@ npx am-i-vibing --debug
 
 ### Exit Codes
 
-- `0` - Agentic environment detected (or specific check passed)
-- `1` - No agentic environment detected (or specific check failed)
+- `0` - Agent detected (or specific check passed)
+- `1` - No agent detected (or specific check failed)
+
+The exit code is determined by agent detection only. A CI runner with no AI agent will exit `1` even though `environment` is populated.
 
 ## Debug Output
 

--- a/packages/am-i-vibing/src/cli.ts
+++ b/packages/am-i-vibing/src/cli.ts
@@ -8,6 +8,7 @@ import {
   isInteractive,
   isHybrid,
 } from "./detector.js";
+import type { AgentInfo, DetectionResult, EnvironmentInfo } from "./types.js";
 
 interface CliOptions {
   format?: "json" | "text";
@@ -55,7 +56,6 @@ function parseCliArgs(): CliOptions {
     allowPositionals: false,
   });
 
-  // Validate format option
   if (values.format && !["json", "text"].includes(values.format)) {
     console.error(
       `Error: Invalid format '${values.format}'. Must be 'json' or 'text'.`,
@@ -63,7 +63,6 @@ function parseCliArgs(): CliOptions {
     process.exit(1);
   }
 
-  // Validate check option
   if (
     values.check &&
     !["agent", "interactive", "hybrid"].includes(values.check)
@@ -110,8 +109,8 @@ EXAMPLES:
   npx am-i-vibing --debug            # Debug with full environment info
 
 EXIT CODES:
-  0  Agentic environment detected (or specific check passed)
-  1  No agentic environment detected (or specific check failed)
+  0  Agent detected (or specific check passed)
+  1  No agent detected (or specific check failed)
 `);
 }
 
@@ -131,15 +130,21 @@ function checkEnvironmentType(
   }
 }
 
-function formatOutput(
-  result: ReturnType<typeof detectAgenticEnvironment>,
-  options: CliOptions,
-): string {
+function formatAgent(agent: AgentInfo): string {
+  const version = agent.version ? ` v${agent.version}` : "";
+  return `[${agent.id}] ${agent.name} (${agent.type})${version}`;
+}
+
+function formatEnvironment(environment: EnvironmentInfo): string {
+  return `[${environment.id}] ${environment.name} (${environment.kind})`;
+}
+
+function formatOutput(result: DetectionResult, options: CliOptions): string {
   if (options.debug) {
     let processAncestry: any[] = [];
     try {
       processAncestry = getProcessAncestry();
-    } catch (error) {
+    } catch {
       processAncestry = [{ error: "Failed to get process ancestry" }];
     }
 
@@ -159,21 +164,37 @@ function formatOutput(
     if (options.check) {
       return checkEnvironmentType(options.check, options) ? "true" : "false";
     }
-    return result.isAgentic ? `${result.name}` : "none";
+    return result.agent?.name ?? "none";
   }
 
   if (options.check) {
     const matches = checkEnvironmentType(options.check, options);
     return matches
-      ? `✓ Running in ${options.check} environment: ${result.name}`
+      ? `✓ Running in ${options.check} environment: ${result.agent?.name}`
       : `✗ Not running in ${options.check} environment`;
   }
 
-  if (!result.isAgentic) {
+  const lines: string[] = [];
+  if (result.agent) {
+    lines.push(`✓ Agent: ${formatAgent(result.agent)}`);
+    if (result.agent.sessionId) {
+      lines.push(`    sessionId: ${result.agent.sessionId}`);
+    }
+  }
+  if (result.environment) {
+    const prefix = result.agent ? "  Environment" : "✓ Environment";
+    lines.push(`${prefix}: ${formatEnvironment(result.environment)}`);
+    if (result.environment.containerId) {
+      lines.push(`    containerId: ${result.environment.containerId}`);
+    }
+    if (result.environment.runId) {
+      lines.push(`    runId: ${result.environment.runId}`);
+    }
+  }
+  if (lines.length === 0) {
     return "✗ No agentic environment detected";
   }
-
-  return `✓ Detected: [${result.id}] ${result.name} (${result.type})`;
+  return lines.join("\n");
 }
 
 function main(): void {

--- a/packages/am-i-vibing/src/detector.ts
+++ b/packages/am-i-vibing/src/detector.ts
@@ -1,20 +1,31 @@
 import type {
+  AgentInfo,
   DetectionResult,
   DetectOptions,
-  ProviderConfig,
+  EnvironmentConfig,
+  EnvironmentInfo,
   EnvVarDefinition,
+  EnvVarExtractor,
   EnvVarGroup,
+  ProviderConfig,
 } from "./types.js";
 import { providers } from "./providers.js";
+import { environments } from "./environments.js";
 import { getProcessAncestry } from "process-ancestry";
+
+type EnvMap = Record<string, string | undefined>;
+type ProcessAncestry = Array<{ command?: string }>;
+
+interface NormalizedOptions {
+  env: EnvMap;
+  processAncestry?: ProcessAncestry;
+  checkProcesses: boolean;
+}
 
 /**
  * Check if a specific environment variable exists (handles both strings and tuples)
  */
-function checkEnvVar(
-  envVarDef: EnvVarDefinition,
-  env: Record<string, string | undefined> = process.env,
-): boolean {
+function checkEnvVar(envVarDef: EnvVarDefinition, env: EnvMap): boolean {
   const [envVar, expectedValue] =
     typeof envVarDef === "string" ? [envVarDef, undefined] : envVarDef;
 
@@ -29,7 +40,7 @@ function checkEnvVar(
  */
 function checkProcess(
   processName: string,
-  processAncestry: Array<{ command?: string }>,
+  processAncestry: ProcessAncestry,
 ): boolean {
   for (const ancestorProcess of processAncestry) {
     if (ancestorProcess.command?.includes(processName)) {
@@ -44,7 +55,7 @@ function checkProcess(
  */
 function checkEnvVars(
   definition: EnvVarGroup | EnvVarDefinition,
-  env: Record<string, string | undefined> = process.env,
+  env: EnvMap,
 ): boolean {
   if (typeof definition === "string" || Array.isArray(definition)) {
     return checkEnvVar(definition, env);
@@ -52,15 +63,10 @@ function checkEnvVars(
 
   const { any, all, none } = definition;
 
-  // Check ANY conditions (OR logic) - at least one must pass
   const anyResult =
     !any?.length || any.some((envVar) => checkEnvVar(envVar, env));
-
-  // Check ALL conditions (AND logic) - all must pass
   const allResult =
     !all?.length || all.every((envVar) => checkEnvVar(envVar, env));
-
-  // Check NONE conditions (NOT logic) - none should pass
   const noneResult =
     !none?.length || !none.some((envVar) => checkEnvVar(envVar, env));
 
@@ -68,11 +74,29 @@ function checkEnvVars(
 }
 
 /**
- * Run custom detectors for a provider
+ * Pull the first non-empty value from a declared env-var extractor.
  */
-function runCustomDetectors(provider: ProviderConfig): boolean {
+function extractValue(
+  extractor: EnvVarExtractor | undefined,
+  env: EnvMap,
+): string | undefined {
+  if (!extractor) return undefined;
+  const names = Array.isArray(extractor) ? extractor : [extractor];
+  for (const name of names) {
+    const value = env[name];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Run custom detectors for a config entry
+ */
+function runCustomDetectors(
+  detectors: ProviderConfig["customDetectors"],
+): boolean {
   return (
-    provider.customDetectors?.some((detector) => {
+    detectors?.some((detector) => {
       try {
         return detector();
       } catch {
@@ -83,19 +107,7 @@ function runCustomDetectors(provider: ProviderConfig): boolean {
 }
 
 /**
- * Create a positive detection result
- */
-function createDetectedResult(provider: ProviderConfig): DetectionResult {
-  return {
-    isAgentic: true,
-    id: provider.id,
-    name: provider.name,
-    type: provider.type,
-  };
-}
-
-/**
- * Normalize the various supported argument shapes into a DetectOptions object.
+ * Normalise the supported argument shapes into a NormalizedOptions object.
  *
  * Supported shapes:
  *   - detectAgenticEnvironment()
@@ -104,13 +116,9 @@ function createDetectedResult(provider: ProviderConfig): DetectionResult {
  *   - detectAgenticEnvironment(env, processAncestry)      // legacy
  */
 function normalizeOptions(
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
-): Required<Pick<DetectOptions, "env" | "checkProcesses">> & {
-  processAncestry?: Array<{ command?: string }>;
-} {
-  // Distinguish a DetectOptions object from a raw env record. DetectOptions
-  // has at least one of the known keys; an env record is a flat string map.
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
+): NormalizedOptions {
   const looksLikeOptions =
     envOrOptions != null &&
     typeof envOrOptions === "object" &&
@@ -131,9 +139,7 @@ function normalizeOptions(
   }
 
   return {
-    env:
-      (envOrOptions as Record<string, string | undefined> | undefined) ??
-      process.env,
+    env: (envOrOptions as EnvMap | undefined) ?? process.env,
     processAncestry: legacyAncestry,
     // Legacy callers that explicitly passed an ancestry are presumed to want
     // process checks; otherwise default off.
@@ -142,79 +148,196 @@ function normalizeOptions(
 }
 
 /**
- * Detect agentic coding environment
+ * Lazily compute and cache the process ancestry on demand.
+ */
+function makeAncestryGetter(seed?: ProcessAncestry): () => ProcessAncestry {
+  let cached = seed;
+  return () => {
+    if (cached === undefined) {
+      try {
+        cached = getProcessAncestry();
+      } catch {
+        cached = [];
+      }
+    }
+    return cached;
+  };
+}
+
+/**
+ * Find the first config that matches. Cheap checks (env vars, then custom
+ * detectors) run across every config first; process-tree checks only run if
+ * `checkProcesses` is enabled, since reading the process tree spawns a
+ * subprocess (notably slow on Windows).
+ */
+function findMatch<T extends ProviderConfig | EnvironmentConfig>(
+  configs: readonly T[],
+  env: EnvMap,
+  checkProcesses: boolean,
+  getAncestry: () => ProcessAncestry,
+): T | null {
+  for (const config of configs) {
+    if (config.envVars?.some((group) => checkEnvVars(group, env))) {
+      return config;
+    }
+  }
+  for (const config of configs) {
+    if (runCustomDetectors(config.customDetectors)) {
+      return config;
+    }
+  }
+  if (checkProcesses) {
+    for (const config of configs) {
+      if (
+        config.processChecks?.some((name) =>
+          checkProcess(name, getAncestry()),
+        )
+      ) {
+        return config;
+      }
+    }
+  }
+  return null;
+}
+
+function buildAgentInfo(
+  provider: ProviderConfig,
+  env: EnvMap,
+): AgentInfo {
+  const info: AgentInfo = {
+    id: provider.id,
+    name: provider.name,
+    type: provider.type,
+  };
+  const version = extractValue(provider.versionEnvVar, env);
+  if (version) info.version = version;
+  const sessionId = extractValue(provider.sessionIdEnvVar, env);
+  if (sessionId) info.sessionId = sessionId;
+  return info;
+}
+
+function buildEnvironmentInfo(
+  environment: EnvironmentConfig,
+  env: EnvMap,
+): EnvironmentInfo {
+  const info: EnvironmentInfo = {
+    id: environment.id,
+    name: environment.name,
+    kind: environment.kind,
+  };
+  const containerId = extractValue(environment.containerIdEnvVar, env);
+  if (containerId) info.containerId = containerId;
+  const runId = extractValue(environment.runIdEnvVar, env);
+  if (runId) info.runId = runId;
+  return info;
+}
+
+/**
+ * Internal helper: find an agent given normalised options and a shared
+ * ancestry getter. Public functions go through this so they can share the
+ * normalisation/ancestry work without ricocheting through overload dispatch.
+ */
+function findAgent(
+  opts: NormalizedOptions,
+  getAncestry: () => ProcessAncestry,
+): AgentInfo | null {
+  const provider = findMatch(
+    providers,
+    opts.env,
+    opts.checkProcesses,
+    getAncestry,
+  );
+  return provider ? buildAgentInfo(provider, opts.env) : null;
+}
+
+/**
+ * Internal helper: find an environment given normalised options and a shared
+ * ancestry getter.
+ */
+function findEnvironment(
+  opts: NormalizedOptions,
+  getAncestry: () => ProcessAncestry,
+): EnvironmentInfo | null {
+  const environment = findMatch(
+    environments,
+    opts.env,
+    opts.checkProcesses,
+    getAncestry,
+  );
+  return environment ? buildEnvironmentInfo(environment, opts.env) : null;
+}
+
+/**
+ * Detect the AI agent driving this process, if any.
+ */
+export function detectAgent(options?: DetectOptions): AgentInfo | null;
+/**
+ * @deprecated Pass an options object instead. This signature is retained for
+ * backwards compatibility and will be removed in a future major release.
+ */
+export function detectAgent(
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
+): AgentInfo | null;
+export function detectAgent(
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
+): AgentInfo | null {
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  return findAgent(opts, makeAncestryGetter(opts.processAncestry));
+}
+
+/**
+ * Detect the runtime environment this process is running in, if recognised.
+ */
+export function detectEnvironment(
+  options?: DetectOptions,
+): EnvironmentInfo | null;
+/**
+ * @deprecated Pass an options object instead.
+ */
+export function detectEnvironment(
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
+): EnvironmentInfo | null;
+export function detectEnvironment(
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
+): EnvironmentInfo | null {
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  return findEnvironment(opts, makeAncestryGetter(opts.processAncestry));
+}
+
+/**
+ * Detect the agent and runtime environment together.
  */
 export function detectAgenticEnvironment(
   options?: DetectOptions,
 ): DetectionResult;
 /**
- * @deprecated Pass an options object instead. This signature is retained for
- * backwards compatibility and will be removed in a future major release.
+ * @deprecated Pass an options object instead.
  */
 export function detectAgenticEnvironment(
-  env: Record<string, string | undefined>,
-  processAncestry?: Array<{ command?: string }>,
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
 ): DetectionResult;
 export function detectAgenticEnvironment(
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
 ): DetectionResult {
-  const { env, processAncestry, checkProcesses } = normalizeOptions(
-    envOrOptions,
-    legacyAncestry,
-  );
-
-  // Fast path: check all environment variables first
-  for (const provider of providers) {
-    if (provider.envVars?.some((group) => checkEnvVars(group, env))) {
-      return createDetectedResult(provider);
-    }
-  }
-
-  // Custom detectors next (cheap, in-process)
-  for (const provider of providers) {
-    if (runCustomDetectors(provider)) {
-      return createDetectedResult(provider);
-    }
-  }
-
-  // Slow path: process ancestry checks. Opt-in only because reading the process
-  // tree spawns a subprocess (notably slow on Windows).
-  if (checkProcesses) {
-    let cachedAncestry = processAncestry;
-    const getAncestry = () => {
-      if (cachedAncestry === undefined) {
-        try {
-          cachedAncestry = getProcessAncestry();
-        } catch {
-          cachedAncestry = [];
-        }
-      }
-      return cachedAncestry;
-    };
-
-    for (const provider of providers) {
-      if (
-        provider.processChecks?.some((processName) =>
-          checkProcess(processName, getAncestry()),
-        )
-      ) {
-        return createDetectedResult(provider);
-      }
-    }
-  }
-
-  // No provider detected
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  const getAncestry = makeAncestryGetter(opts.processAncestry);
+  const agent = findAgent(opts, getAncestry);
+  const environment = findEnvironment(opts, getAncestry);
   return {
-    isAgentic: false,
-    id: null,
-    name: null,
-    type: null,
+    isAgentic: agent !== null,
+    agent,
+    environment,
   };
 }
 
 /**
- * Check if currently running in a specific provider
+ * Check if currently running under a specific provider (by name)
  */
 export function isProvider(
   providerName: string,
@@ -225,19 +348,19 @@ export function isProvider(
  */
 export function isProvider(
   providerName: string,
-  env: Record<string, string | undefined>,
-  processAncestry?: Array<{ command?: string }>,
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
 ): boolean;
 export function isProvider(
   providerName: string,
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
 ): boolean {
-  const result = detectAgenticEnvironment(
-    envOrOptions as DetectOptions,
-    legacyAncestry as Array<{ command?: string }> | undefined,
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  return (
+    findAgent(opts, makeAncestryGetter(opts.processAncestry))?.name ===
+    providerName
   );
-  return result.name === providerName;
 }
 
 /**
@@ -248,18 +371,16 @@ export function isAgent(options?: DetectOptions): boolean;
  * @deprecated Pass an options object instead.
  */
 export function isAgent(
-  env: Record<string, string | undefined>,
-  processAncestry?: Array<{ command?: string }>,
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
 ): boolean;
 export function isAgent(
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
 ): boolean {
-  const result = detectAgenticEnvironment(
-    envOrOptions as DetectOptions,
-    legacyAncestry as Array<{ command?: string }> | undefined,
-  );
-  return result.type === "agent" || result.type === "hybrid";
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  const agent = findAgent(opts, makeAncestryGetter(opts.processAncestry));
+  return agent?.type === "agent" || agent?.type === "hybrid";
 }
 
 /**
@@ -270,18 +391,16 @@ export function isInteractive(options?: DetectOptions): boolean;
  * @deprecated Pass an options object instead.
  */
 export function isInteractive(
-  env: Record<string, string | undefined>,
-  processAncestry?: Array<{ command?: string }>,
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
 ): boolean;
 export function isInteractive(
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
 ): boolean {
-  const result = detectAgenticEnvironment(
-    envOrOptions as DetectOptions,
-    legacyAncestry as Array<{ command?: string }> | undefined,
-  );
-  return result.type === "interactive" || result.type === "hybrid";
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  const agent = findAgent(opts, makeAncestryGetter(opts.processAncestry));
+  return agent?.type === "interactive" || agent?.type === "hybrid";
 }
 
 /**
@@ -292,16 +411,16 @@ export function isHybrid(options?: DetectOptions): boolean;
  * @deprecated Pass an options object instead.
  */
 export function isHybrid(
-  env: Record<string, string | undefined>,
-  processAncestry?: Array<{ command?: string }>,
+  env: EnvMap,
+  processAncestry?: ProcessAncestry,
 ): boolean;
 export function isHybrid(
-  envOrOptions?: Record<string, string | undefined> | DetectOptions,
-  legacyAncestry?: Array<{ command?: string }>,
+  envOrOptions?: EnvMap | DetectOptions,
+  legacyAncestry?: ProcessAncestry,
 ): boolean {
-  const result = detectAgenticEnvironment(
-    envOrOptions as DetectOptions,
-    legacyAncestry as Array<{ command?: string }> | undefined,
+  const opts = normalizeOptions(envOrOptions, legacyAncestry);
+  return (
+    findAgent(opts, makeAncestryGetter(opts.processAncestry))?.type ===
+    "hybrid"
   );
-  return result.type === "hybrid";
 }

--- a/packages/am-i-vibing/src/environments.ts
+++ b/packages/am-i-vibing/src/environments.ts
@@ -1,0 +1,115 @@
+import type { EnvironmentConfig } from "./types.js";
+
+/**
+ * Environment configurations for runtime sandboxes, CI runners, IDEs, and WebContainers.
+ *
+ * Environments are detected independently of agents: a result can have an agent
+ * with no environment, an environment with no agent, or both.
+ */
+export const environments: EnvironmentConfig[] = [
+  {
+    id: "claude-code-cloud",
+    name: "Claude Code Cloud",
+    kind: "cloud-sandbox",
+    envVars: [
+      {
+        any: [["CLAUDE_CODE_REMOTE", "true"], "CLAUDE_CODE_CONTAINER_ID"],
+      },
+    ],
+    containerIdEnvVar: "CLAUDE_CODE_CONTAINER_ID",
+  },
+  {
+    id: "github-actions",
+    name: "GitHub Actions",
+    kind: "ci-runner",
+    envVars: [["GITHUB_ACTIONS", "true"]],
+    containerIdEnvVar: "RUNNER_NAME",
+    runIdEnvVar: "GITHUB_RUN_ID",
+  },
+  {
+    id: "gitlab-ci",
+    name: "GitLab CI",
+    kind: "ci-runner",
+    envVars: [["GITLAB_CI", "true"]],
+    runIdEnvVar: "CI_JOB_ID",
+  },
+  {
+    id: "circleci",
+    name: "CircleCI",
+    kind: "ci-runner",
+    envVars: [["CIRCLECI", "true"]],
+    runIdEnvVar: "CIRCLE_BUILD_NUM",
+  },
+  {
+    id: "buildkite",
+    name: "Buildkite",
+    kind: "ci-runner",
+    envVars: [["BUILDKITE", "true"]],
+    containerIdEnvVar: "BUILDKITE_AGENT_NAME",
+    runIdEnvVar: "BUILDKITE_BUILD_ID",
+  },
+  {
+    id: "replit-cloud",
+    name: "Replit",
+    kind: "cloud-sandbox",
+    envVars: ["REPL_ID"],
+    containerIdEnvVar: "REPL_ID",
+  },
+  {
+    id: "jules-cloud",
+    name: "Jules",
+    kind: "cloud-sandbox",
+    envVars: [
+      {
+        all: [
+          ["HOME", "/home/jules"],
+          ["USER", "swebot"],
+        ],
+      },
+    ],
+  },
+  {
+    id: "webcontainer",
+    name: "WebContainer",
+    kind: "webcontainer",
+    envVars: [
+      {
+        all: [["SHELL", "/bin/jsh"]],
+      },
+    ],
+  },
+  {
+    id: "cursor",
+    name: "Cursor",
+    kind: "ide",
+    envVars: ["CURSOR_TRACE_ID"],
+  },
+  {
+    id: "vscode",
+    name: "Visual Studio Code",
+    kind: "ide",
+    envVars: [["TERM_PROGRAM", "vscode"]],
+  },
+  {
+    id: "zed",
+    name: "Zed",
+    kind: "ide",
+    envVars: [["TERM_PROGRAM", "zed"]],
+  },
+];
+
+/**
+ * Get environment configuration by id
+ */
+export function getEnvironment(id: string): EnvironmentConfig | undefined {
+  return environments.find((e) => e.id === id);
+}
+
+/**
+ * Get all environments of a specific kind
+ */
+export function getEnvironmentsByKind(
+  kind: EnvironmentConfig["kind"],
+): EnvironmentConfig[] {
+  return environments.filter((e) => e.kind === kind);
+}

--- a/packages/am-i-vibing/src/index.ts
+++ b/packages/am-i-vibing/src/index.ts
@@ -5,23 +5,35 @@
 // Export types
 export type {
   AgenticType,
-  ProviderConfig,
+  AgentInfo,
   DetectionResult,
   DetectOptions,
+  EnvironmentConfig,
+  EnvironmentInfo,
+  EnvironmentKind,
   EnvVarDefinition,
+  EnvVarExtractor,
   EnvVarGroup,
+  ProviderConfig,
 } from "./types.js";
 
-// Export providers
+// Export providers and environments
 export { providers, getProvider, getProvidersByType } from "./providers.js";
+export {
+  environments,
+  getEnvironment,
+  getEnvironmentsByKind,
+} from "./environments.js";
 
 // Export detection functions
 export {
+  detectAgent,
   detectAgenticEnvironment,
-  isProvider,
+  detectEnvironment,
   isAgent,
-  isInteractive,
   isHybrid,
+  isInteractive,
+  isProvider,
 } from "./detector.js";
 
 // Import for default export

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -38,6 +38,8 @@ export const providers: ProviderConfig[] = [
     name: "Claude Code",
     type: "agent",
     envVars: ["CLAUDECODE"],
+    versionEnvVar: "CLAUDE_CODE_VERSION",
+    sessionIdEnvVar: ["CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_REMOTE_SESSION_ID"],
   },
   {
     id: "cursor-agent",
@@ -48,12 +50,14 @@ export const providers: ProviderConfig[] = [
         all: ["CURSOR_TRACE_ID", ["PAGER", "head -n 10000 | cat"]],
       },
     ],
+    sessionIdEnvVar: "CURSOR_TRACE_ID",
   },
   {
     id: "cursor",
     name: "Cursor",
     type: "interactive",
     envVars: ["CURSOR_TRACE_ID"],
+    sessionIdEnvVar: "CURSOR_TRACE_ID",
   },
   {
     id: "gemini-agent",
@@ -72,6 +76,7 @@ export const providers: ProviderConfig[] = [
     // See: https://github.com/openai/codex/blob/main/codex-rs/protocol/src/shell_environment.rs
     envVars: ["CODEX_THREAD_ID"],
     processChecks: ["codex"],
+    sessionIdEnvVar: "CODEX_THREAD_ID",
   },
   {
     id: "replit",

--- a/packages/am-i-vibing/src/types.ts
+++ b/packages/am-i-vibing/src/types.ts
@@ -4,6 +4,15 @@
 export type AgenticType = "agent" | "interactive" | "hybrid";
 
 /**
+ * The kind of runtime environment a process is executing in
+ */
+export type EnvironmentKind =
+  | "cloud-sandbox"
+  | "ci-runner"
+  | "ide"
+  | "webcontainer";
+
+/**
  * Environment variable definition - either just a name or a name/value tuple
  */
 export type EnvVarDefinition = string | [string, string];
@@ -23,7 +32,13 @@ export interface EnvVarGroup {
 }
 
 /**
- * Configuration for detecting a specific AI coding provider
+ * Declarative extractor: the env var(s) to read for a given field.
+ * If an array is given, the first non-empty value wins.
+ */
+export type EnvVarExtractor = string | string[];
+
+/**
+ * Configuration for detecting a specific AI coding agent
  */
 export interface ProviderConfig {
   /** Unique identifier for the provider */
@@ -43,23 +58,105 @@ export interface ProviderConfig {
 
   /** Custom detection functions for complex logic */
   customDetectors?: (() => boolean)[];
+
+  /** Env var(s) to read for the agent's reported version */
+  versionEnvVar?: EnvVarExtractor;
+
+  /** Env var(s) to read for the agent's session/conversation id */
+  sessionIdEnvVar?: EnvVarExtractor;
 }
 
 /**
- * Result of agentic environment detection
+ * Configuration for detecting a runtime environment (cloud sandbox, CI runner, etc.)
+ */
+export interface EnvironmentConfig {
+  /** Unique identifier for the environment */
+  id: string;
+
+  /** Human-readable name of the environment */
+  name: string;
+
+  /** Kind of runtime environment */
+  kind: EnvironmentKind;
+
+  /** Environment variables */
+  envVars?: Array<EnvVarGroup | EnvVarDefinition>;
+
+  /** Process names to check for in the process tree */
+  processChecks?: string[];
+
+  /** Custom detection functions for complex logic */
+  customDetectors?: (() => boolean)[];
+
+  /** Env var(s) to read for a stable container/sandbox identifier */
+  containerIdEnvVar?: EnvVarExtractor;
+
+  /** Env var(s) to read for an execution/run identifier */
+  runIdEnvVar?: EnvVarExtractor;
+}
+
+/**
+ * Information about the detected AI agent
+ */
+export interface AgentInfo {
+  /** Unique identifier for the agent */
+  id: string;
+
+  /** Human-readable name of the agent */
+  name: string;
+
+  /** Type of AI coding environment */
+  type: AgenticType;
+
+  /** Reported version of the agent, if available */
+  version?: string;
+
+  /** Session/conversation identifier, if available */
+  sessionId?: string;
+}
+
+/**
+ * Information about the detected runtime environment
+ */
+export interface EnvironmentInfo {
+  /** Unique identifier for the environment */
+  id: string;
+
+  /** Human-readable name of the environment */
+  name: string;
+
+  /** Kind of runtime environment */
+  kind: EnvironmentKind;
+
+  /** Stable container/sandbox identifier, if available */
+  containerId?: string;
+
+  /** Execution/run identifier, if available */
+  runId?: string;
+}
+
+/**
+ * Result of agentic environment detection.
+ *
+ * Prefer destructuring the fields you use rather than passing the whole
+ * result object around:
+ *
+ * ```ts
+ * const { agent, environment } = detectAgenticEnvironment();
+ * ```
+ *
+ * New top-level fields may be added in future versions. Destructuring keeps
+ * your code forward-compatible with those additions.
  */
 export interface DetectionResult {
-  /** Whether an agentic environment was detected */
+  /** Whether an AI agent was detected */
   isAgentic: boolean;
 
-  /** ID of the detected provider, if any */
-  id: string | null;
+  /** Detected AI agent, or null if none */
+  agent: AgentInfo | null;
 
-  /** Name of the detected provider, if any */
-  name: string | null;
-
-  /** Type of agentic environment, if detected */
-  type: AgenticType | null;
+  /** Detected runtime environment, or null if none recognised */
+  environment: EnvironmentInfo | null;
 }
 
 /**

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -1,322 +1,436 @@
 import { describe, it, expect } from "vitest";
 import {
+  detectAgent,
   detectAgenticEnvironment,
+  detectEnvironment,
   isAgent,
-  isInteractive,
   isHybrid,
+  isInteractive,
+  isProvider,
 } from "../src/detector.js";
 
 describe("detectAgenticEnvironment", () => {
-  it("should return false for non-agentic environment", () => {
+  it("returns a fully null result for a non-agentic environment", () => {
     const result = detectAgenticEnvironment({ env: {} });
     expect(result.isAgentic).toBe(false);
-    expect(result.name).toBe(null);
+    expect(result.agent).toBe(null);
+    expect(result.environment).toBe(null);
   });
 
-  it("should detect Jules environment", () => {
-    const env = {
-      HOME: "/home/jules",
-      USER: "swebot",
-    };
-    const result = detectAgenticEnvironment({ env });
+  it("detects Jules", () => {
+    const result = detectAgenticEnvironment({
+      env: { HOME: "/home/jules", USER: "swebot" },
+    });
     expect(result.isAgentic).toBe(true);
-    expect(result.name).toBe("Jules");
-    expect(result.id).toBe("jules");
+    expect(result.agent?.id).toBe("jules");
+    expect(result.agent?.name).toBe("Jules");
+    expect(result.environment?.id).toBe("jules-cloud");
   });
 
-  it("should detect Claude Code environment", () => {
+  it("detects Claude Code", () => {
     const result = detectAgenticEnvironment({ env: { CLAUDECODE: "true" } });
-
     expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("claude-code");
-    expect(result.name).toBe("Claude Code");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("claude-code");
+    expect(result.agent?.name).toBe("Claude Code");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Cursor environment", () => {
+  it("detects Cursor as interactive", () => {
     const result = detectAgenticEnvironment({
       env: { CURSOR_TRACE_ID: "cursor-trace-123" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("cursor");
-    expect(result.name).toBe("Cursor");
-    expect(result.type).toBe("interactive");
+    expect(result.agent?.id).toBe("cursor");
+    expect(result.agent?.name).toBe("Cursor");
+    expect(result.agent?.type).toBe("interactive");
   });
 
-  it("should detect GitHub Copilot Agent environment", () => {
+  it("detects GitHub Copilot in VS Code", () => {
     const result = detectAgenticEnvironment({
-      env: {
-        TERM_PROGRAM: "vscode",
-        GIT_PAGER: "cat",
-      },
+      env: { TERM_PROGRAM: "vscode", GIT_PAGER: "cat" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("vscode-copilot-agent");
-    expect(result.name).toBe("GitHub Copilot in VS Code");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("vscode-copilot-agent");
+    expect(result.agent?.name).toBe("GitHub Copilot in VS Code");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Cursor Agent environment", () => {
+  it("detects Cursor Agent (more specific) before Cursor", () => {
     const result = detectAgenticEnvironment({
       env: {
         CURSOR_TRACE_ID: "cursor-trace-123",
         PAGER: "head -n 10000 | cat",
       },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("cursor-agent");
-    expect(result.name).toBe("Cursor Agent");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("cursor-agent");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Replit AI environment", () => {
-    const result = detectAgenticEnvironment({ env: { REPL_ID: "repl-123" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("replit");
-    expect(result.name).toBe("Replit");
-    expect(result.type).toBe("agent");
+  it("detects Replit", () => {
+    const result = detectAgenticEnvironment({
+      env: { REPL_ID: "repl-123" },
+    });
+    expect(result.agent?.id).toBe("replit");
+    expect(result.agent?.name).toBe("Replit");
+    expect(result.environment?.id).toBe("replit-cloud");
   });
 
-  it("should detect OpenCode environment", () => {
+  it("detects OpenCode", () => {
     const result = detectAgenticEnvironment({ env: { OPENCODE: "1" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("opencode");
-    expect(result.name).toBe("OpenCode");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("opencode");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect OpenCode environment via legacy env vars", () => {
+  it("detects OpenCode via legacy env vars", () => {
     const result = detectAgenticEnvironment({
       env: { OPENCODE_BIN_PATH: "/usr/local/bin/opencode" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("opencode");
-    expect(result.name).toBe("OpenCode");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("opencode");
   });
 
-  it("should detect Aider environment", () => {
+  it("detects Aider", () => {
     const result = detectAgenticEnvironment({
       env: { AIDER_API_KEY: "aider-key" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("aider");
-    expect(result.name).toBe("Aider");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("aider");
   });
 
-  it("should detect Bolt.new Agent environment", () => {
+  it("detects Bolt.new Agent", () => {
     const result = detectAgenticEnvironment({
-      env: {
-        SHELL: "/bin/jsh",
-        npm_config_yes: "true",
-      },
+      env: { SHELL: "/bin/jsh", npm_config_yes: "true" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("bolt-agent");
-    expect(result.name).toBe("Bolt.new Agent");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("bolt-agent");
+    expect(result.environment?.id).toBe("webcontainer");
   });
 
-  it("should detect Bolt.new interactive environment", () => {
+  it("detects Bolt.new interactive", () => {
     const result = detectAgenticEnvironment({ env: { SHELL: "/bin/jsh" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("bolt");
-    expect(result.name).toBe("Bolt.new");
-    expect(result.type).toBe("interactive");
+    expect(result.agent?.id).toBe("bolt");
+    expect(result.environment?.id).toBe("webcontainer");
   });
 
-  it("should detect Zed Agent environment", () => {
+  it("detects Zed Agent", () => {
     const result = detectAgenticEnvironment({
-      env: {
-        TERM_PROGRAM: "zed",
-        PAGER: "cat",
-      },
+      env: { TERM_PROGRAM: "zed", PAGER: "cat" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("zed-agent");
-    expect(result.name).toBe("Zed Agent");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("zed-agent");
+    expect(result.environment?.id).toBe("zed");
   });
 
-  it("should detect Zed interactive environment", () => {
+  it("detects Zed interactive", () => {
     const result = detectAgenticEnvironment({ env: { TERM_PROGRAM: "zed" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("zed");
-    expect(result.name).toBe("Zed");
-    expect(result.type).toBe("interactive");
+    expect(result.agent?.id).toBe("zed");
   });
 
-  it("should detect Warp hybrid environment", () => {
+  it("detects Warp as hybrid", () => {
     const result = detectAgenticEnvironment({
       env: { TERM_PROGRAM: "WarpTerminal" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("warp");
-    expect(result.name).toBe("Warp Terminal");
-    expect(result.type).toBe("hybrid");
+    expect(result.agent?.id).toBe("warp");
+    expect(result.agent?.type).toBe("hybrid");
   });
 
-  it("should detect Gemini CLI via GEMINI_CLI env var", () => {
+  it("detects Gemini CLI via GEMINI_CLI env var", () => {
     const result = detectAgenticEnvironment({ env: { GEMINI_CLI: "1" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("gemini-agent");
-    expect(result.name).toBe("Gemini CLI");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("gemini-agent");
+    expect(result.agent?.name).toBe("Gemini CLI");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should not detect Gemini CLI when GEMINI_CLI has the wrong value", () => {
-    // Gemini specifically sets GEMINI_CLI=1; any other value shouldn't match.
+  it("does not detect Gemini CLI when GEMINI_CLI has the wrong value", () => {
     const result = detectAgenticEnvironment({
       env: { GEMINI_CLI: "something-else" },
     });
     expect(result.isAgentic).toBe(false);
   });
 
-  it("should detect Codex via CODEX_THREAD_ID env var", () => {
+  it("detects Codex via CODEX_THREAD_ID env var", () => {
     const result = detectAgenticEnvironment({
       env: { CODEX_THREAD_ID: "thread-abc" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("codex");
-    expect(result.name).toBe("OpenAI Codex");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("codex");
+    expect(result.agent?.name).toBe("OpenAI Codex");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Crush via CRUSH=1 env var", () => {
+  it("detects Crush via CRUSH=1 env var", () => {
     const result = detectAgenticEnvironment({ env: { CRUSH: "1" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("crush");
-    expect(result.name).toBe("Crush");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("crush");
+    expect(result.agent?.name).toBe("Crush");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Crush via AGENT=crush env var", () => {
+  it("detects Crush via AGENT=crush env var", () => {
     const result = detectAgenticEnvironment({ env: { AGENT: "crush" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("crush");
+    expect(result.agent?.id).toBe("crush");
   });
 
-  it("should detect Amp via AMP_CURRENT_THREAD_ID env var", () => {
+  it("detects Amp via AMP_CURRENT_THREAD_ID env var", () => {
     const result = detectAgenticEnvironment({
       env: { AMP_CURRENT_THREAD_ID: "T-abc123" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("amp");
-    expect(result.name).toBe("Amp");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("amp");
+    expect(result.agent?.name).toBe("Amp");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Amp via AGENT=amp env var", () => {
+  it("detects Amp via AGENT=amp env var", () => {
     const result = detectAgenticEnvironment({ env: { AGENT: "amp" } });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("amp");
+    expect(result.agent?.id).toBe("amp");
   });
 
-  it("should detect Auggie via AUGMENT_AGENT=1 env var", () => {
+  it("detects Auggie via AUGMENT_AGENT=1 env var", () => {
     const result = detectAgenticEnvironment({
       env: { AUGMENT_AGENT: "1" },
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("auggie");
-    expect(result.name).toBe("Auggie");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("auggie");
+    expect(result.agent?.name).toBe("Auggie");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should not detect Auggie when AUGMENT_AGENT has the wrong value", () => {
+  it("does not detect Auggie when AUGMENT_AGENT has the wrong value", () => {
     const result = detectAgenticEnvironment({
       env: { AUGMENT_AGENT: "0" },
     });
-
     expect(result.isAgentic).toBe(false);
   });
 
-  it("should detect Qwen Code via QWEN_CODE=1 env var", () => {
-    const result = detectAgenticEnvironment({
-      env: { QWEN_CODE: "1" },
-    });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("qwen-code");
-    expect(result.name).toBe("Qwen Code");
-    expect(result.type).toBe("agent");
+  it("detects Qwen Code via QWEN_CODE=1 env var", () => {
+    const result = detectAgenticEnvironment({ env: { QWEN_CODE: "1" } });
+    expect(result.agent?.id).toBe("qwen-code");
+    expect(result.agent?.name).toBe("Qwen Code");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should handle false positive scenarios", () => {
+  it("returns a non-agentic result when no signals match", () => {
     const result = detectAgenticEnvironment({
       env: { RANDOM_VARIABLE: "some-value" },
     });
-
     expect(result.isAgentic).toBe(false);
   });
+});
 
-  it("should distinguish between agent and interactive variants", () => {
-    const agentResult = detectAgenticEnvironment({
-      env: {
-        CURSOR_TRACE_ID: "cursor-trace-123",
-        PAGER: "head -n 10000 | cat",
-      },
-    });
-
-    expect(agentResult.id).toBe("cursor-agent");
-    expect(agentResult.name).toBe("Cursor Agent");
-    expect(agentResult.type).toBe("agent");
-
-    const interactiveResult = detectAgenticEnvironment({
-      env: { CURSOR_TRACE_ID: "cursor-trace-123" },
-    });
-
-    expect(interactiveResult.id).toBe("cursor");
-    expect(interactiveResult.name).toBe("Cursor");
-    expect(interactiveResult.type).toBe("interactive");
+describe("detectAgent", () => {
+  it("returns null when nothing matches", () => {
+    expect(detectAgent({ env: {} })).toBe(null);
   });
 
-  it("should distinguish between Zed agent and interactive variants", () => {
-    const agentResult = detectAgenticEnvironment({
+  it("populates version when versionEnvVar is set on the provider", () => {
+    const agent = detectAgent({
+      env: { CLAUDECODE: "1", CLAUDE_CODE_VERSION: "2.1.42" },
+    });
+    expect(agent?.id).toBe("claude-code");
+    expect(agent?.version).toBe("2.1.42");
+  });
+
+  it("populates sessionId from the first non-empty extractor entry", () => {
+    const agent = detectAgent({
       env: {
-        TERM_PROGRAM: "zed",
-        PAGER: "cat",
+        CLAUDECODE: "1",
+        CLAUDE_CODE_REMOTE_SESSION_ID: "remote-session",
       },
     });
+    expect(agent?.sessionId).toBe("remote-session");
+  });
 
-    expect(agentResult.id).toBe("zed-agent");
-    expect(agentResult.name).toBe("Zed Agent");
-    expect(agentResult.type).toBe("agent");
-
-    const interactiveResult = detectAgenticEnvironment({
-      env: { TERM_PROGRAM: "zed" },
+  it("prefers earlier extractor entries when multiple are set", () => {
+    const agent = detectAgent({
+      env: {
+        CLAUDECODE: "1",
+        CLAUDE_CODE_SESSION_ID: "primary",
+        CLAUDE_CODE_REMOTE_SESSION_ID: "fallback",
+      },
     });
+    expect(agent?.sessionId).toBe("primary");
+  });
 
-    expect(interactiveResult.id).toBe("zed");
-    expect(interactiveResult.name).toBe("Zed");
-    expect(interactiveResult.type).toBe("interactive");
+  it("populates Cursor sessionId from CURSOR_TRACE_ID", () => {
+    const agent = detectAgent({ env: { CURSOR_TRACE_ID: "trace-xyz" } });
+    expect(agent?.sessionId).toBe("trace-xyz");
+  });
+
+  it("populates Codex sessionId from CODEX_THREAD_ID", () => {
+    const agent = detectAgent({ env: { CODEX_THREAD_ID: "thread-xyz" } });
+    expect(agent?.id).toBe("codex");
+    expect(agent?.sessionId).toBe("thread-xyz");
+  });
+
+  it("omits version and sessionId when no env vars are present", () => {
+    const agent = detectAgent({ env: { CLAUDECODE: "1" } });
+    expect(agent?.version).toBeUndefined();
+    expect(agent?.sessionId).toBeUndefined();
+  });
+});
+
+describe("detectEnvironment", () => {
+  it("returns null when no environment signal is present", () => {
+    expect(detectEnvironment({ env: {} })).toBe(null);
+  });
+
+  it("detects Claude Code Cloud via CLAUDE_CODE_REMOTE", () => {
+    const env = detectEnvironment({
+      env: {
+        CLAUDE_CODE_REMOTE: "true",
+        CLAUDE_CODE_CONTAINER_ID: "container_xyz",
+      },
+    });
+    expect(env?.id).toBe("claude-code-cloud");
+    expect(env?.kind).toBe("cloud-sandbox");
+    expect(env?.containerId).toBe("container_xyz");
+  });
+
+  it("detects Claude Code Cloud via container id alone", () => {
+    const env = detectEnvironment({
+      env: { CLAUDE_CODE_CONTAINER_ID: "container_xyz" },
+    });
+    expect(env?.id).toBe("claude-code-cloud");
+  });
+
+  it("detects GitHub Actions and extracts containerId + runId", () => {
+    const env = detectEnvironment({
+      env: {
+        GITHUB_ACTIONS: "true",
+        GITHUB_RUN_ID: "42",
+        RUNNER_NAME: "ubuntu-latest-1",
+      },
+    });
+    expect(env?.id).toBe("github-actions");
+    expect(env?.kind).toBe("ci-runner");
+    expect(env?.containerId).toBe("ubuntu-latest-1");
+    expect(env?.runId).toBe("42");
+  });
+
+  it("detects GitLab CI and extracts runId", () => {
+    const env = detectEnvironment({
+      env: { GITLAB_CI: "true", CI_JOB_ID: "9001" },
+    });
+    expect(env?.id).toBe("gitlab-ci");
+    expect(env?.runId).toBe("9001");
+  });
+
+  it("detects CircleCI", () => {
+    const env = detectEnvironment({
+      env: { CIRCLECI: "true", CIRCLE_BUILD_NUM: "777" },
+    });
+    expect(env?.id).toBe("circleci");
+    expect(env?.runId).toBe("777");
+  });
+
+  it("detects Buildkite", () => {
+    const env = detectEnvironment({
+      env: {
+        BUILDKITE: "true",
+        BUILDKITE_AGENT_NAME: "agent-1",
+        BUILDKITE_BUILD_ID: "build-1",
+      },
+    });
+    expect(env?.id).toBe("buildkite");
+    expect(env?.containerId).toBe("agent-1");
+    expect(env?.runId).toBe("build-1");
+  });
+
+  it("detects Replit cloud and uses REPL_ID as containerId", () => {
+    const env = detectEnvironment({ env: { REPL_ID: "repl-abc" } });
+    expect(env?.id).toBe("replit-cloud");
+    expect(env?.containerId).toBe("repl-abc");
+  });
+
+  it("detects WebContainer via SHELL=/bin/jsh", () => {
+    const env = detectEnvironment({ env: { SHELL: "/bin/jsh" } });
+    expect(env?.id).toBe("webcontainer");
+    expect(env?.kind).toBe("webcontainer");
+  });
+
+  it("detects VS Code as IDE", () => {
+    const env = detectEnvironment({ env: { TERM_PROGRAM: "vscode" } });
+    expect(env?.id).toBe("vscode");
+    expect(env?.kind).toBe("ide");
+  });
+
+  it("detects Cursor as IDE", () => {
+    const env = detectEnvironment({ env: { CURSOR_TRACE_ID: "trace-xyz" } });
+    expect(env?.id).toBe("cursor");
+    expect(env?.kind).toBe("ide");
+  });
+
+  it("detects Zed as IDE", () => {
+    const env = detectEnvironment({ env: { TERM_PROGRAM: "zed" } });
+    expect(env?.id).toBe("zed");
+  });
+
+  it("detects Jules sandbox", () => {
+    const env = detectEnvironment({
+      env: { HOME: "/home/jules", USER: "swebot" },
+    });
+    expect(env?.id).toBe("jules-cloud");
+    expect(env?.kind).toBe("cloud-sandbox");
+  });
+});
+
+describe("composed agent + environment results", () => {
+  it("populates only agent when no environment signal is present", () => {
+    const result = detectAgenticEnvironment({ env: { CLAUDECODE: "1" } });
+    expect(result.agent?.id).toBe("claude-code");
+    expect(result.environment).toBe(null);
+  });
+
+  it("populates only environment when no agent matches", () => {
+    const result = detectAgenticEnvironment({
+      env: { GITHUB_ACTIONS: "true", GITHUB_RUN_ID: "42" },
+    });
+    expect(result.isAgentic).toBe(false);
+    expect(result.agent).toBe(null);
+    expect(result.environment?.id).toBe("github-actions");
+    expect(result.environment?.runId).toBe("42");
+  });
+
+  it("populates both halves for Claude Code in the cloud sandbox", () => {
+    const result = detectAgenticEnvironment({
+      env: {
+        CLAUDECODE: "1",
+        CLAUDE_CODE_VERSION: "2.1.42",
+        CLAUDE_CODE_SESSION_ID: "cse_01abc",
+        CLAUDE_CODE_REMOTE: "true",
+        CLAUDE_CODE_CONTAINER_ID: "container_xyz",
+      },
+    });
+    expect(result.agent?.id).toBe("claude-code");
+    expect(result.agent?.version).toBe("2.1.42");
+    expect(result.agent?.sessionId).toBe("cse_01abc");
+    expect(result.environment?.id).toBe("claude-code-cloud");
+    expect(result.environment?.containerId).toBe("container_xyz");
+  });
+
+  it("populates both halves for Claude Code on a GitHub Actions runner", () => {
+    const result = detectAgenticEnvironment({
+      env: {
+        CLAUDECODE: "1",
+        CLAUDE_CODE_VERSION: "2.1.42",
+        GITHUB_ACTIONS: "true",
+        GITHUB_RUN_ID: "9999",
+        RUNNER_NAME: "ubuntu-latest-1",
+      },
+    });
+    expect(result.agent?.id).toBe("claude-code");
+    expect(result.environment?.id).toBe("github-actions");
+    expect(result.environment?.containerId).toBe("ubuntu-latest-1");
+    expect(result.environment?.runId).toBe("9999");
+  });
+
+  it("isAgentic is determined by agent presence, not environment", () => {
+    const ciOnly = detectAgenticEnvironment({
+      env: { GITHUB_ACTIONS: "true" },
+    });
+    expect(ciOnly.isAgentic).toBe(false);
+
+    const agentOnly = detectAgenticEnvironment({ env: { CLAUDECODE: "1" } });
+    expect(agentOnly.isAgentic).toBe(true);
   });
 });
 
 describe("process ancestry detection (opt-in)", () => {
-  it("should NOT consult processChecks by default", () => {
+  it("does NOT consult processChecks by default", () => {
     // Octofriend is detectable only via processChecks. With checkProcesses
-    // disabled (the default), passing an ancestry that names octofriend should
-    // not yield a match.
+    // disabled (the default), passing an ancestry that names octofriend
+    // should not yield a match.
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "octofriend-cli" }],
@@ -325,57 +439,48 @@ describe("process ancestry detection (opt-in)", () => {
     expect(result.isAgentic).toBe(false);
   });
 
-  it("should detect Octofriend when checkProcesses is enabled", () => {
+  it("detects Octofriend when checkProcesses is enabled", () => {
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "octofriend-cli" }],
       checkProcesses: true,
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("octofriend");
-    expect(result.name).toBe("Octofriend");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("octofriend");
+    expect(result.agent?.name).toBe("Octofriend");
+    expect(result.agent?.type).toBe("agent");
   });
 
-  it("should detect Devin via process ancestry when checkProcesses is enabled", () => {
+  it("detects Devin via process ancestry when checkProcesses is enabled", () => {
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "/Users/me/.local/bin/devin" }],
       checkProcesses: true,
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("devin");
-    expect(result.name).toBe("Devin");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("devin");
+    expect(result.agent?.name).toBe("Devin");
   });
 
-  it("should detect Factory Droid via process ancestry when checkProcesses is enabled", () => {
+  it("detects Factory Droid via process ancestry when checkProcesses is enabled", () => {
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "/usr/local/bin/droid" }],
       checkProcesses: true,
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("droid");
-    expect(result.name).toBe("Factory Droid");
-    expect(result.type).toBe("agent");
+    expect(result.agent?.id).toBe("droid");
+    expect(result.agent?.name).toBe("Factory Droid");
   });
 
-  it("should default checkProcesses to true when processAncestry is supplied without an explicit flag", () => {
+  it("defaults checkProcesses to true when processAncestry is supplied without an explicit flag", () => {
     // Convenience: passing ancestry without saying checkProcesses=true is
     // treated as opt-in, so callers don't have to set both.
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "node /path/to/octofriend" }],
     });
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("octofriend");
+    expect(result.agent?.id).toBe("octofriend");
   });
 
-  it("should still honor an explicit checkProcesses: false even when ancestry is supplied", () => {
+  it("honours an explicit checkProcesses: false even when ancestry is supplied", () => {
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "octofriend" }],
@@ -384,33 +489,27 @@ describe("process ancestry detection (opt-in)", () => {
     expect(result.isAgentic).toBe(false);
   });
 
-  it("should prefer env var matches over process ancestry", () => {
-    // Env var match should win even if ancestry would also match a different
-    // provider.
+  it("env-var match wins over a colliding process check", () => {
     const result = detectAgenticEnvironment({
       env: { CLAUDECODE: "true" },
       processAncestry: [{ command: "gemini" }, { command: "octofriend" }],
       checkProcesses: true,
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("claude-code");
+    expect(result.agent?.id).toBe("claude-code");
   });
 
-  it("should fall back to process ancestry when env vars don't match", () => {
+  it("falls back to process ancestry when env vars do not match", () => {
     const result = detectAgenticEnvironment({
       env: {},
       processAncestry: [{ command: "/usr/local/bin/octofriend" }],
       checkProcesses: true,
     });
-
-    expect(result.isAgentic).toBe(true);
-    expect(result.id).toBe("octofriend");
+    expect(result.agent?.id).toBe("octofriend");
   });
 });
 
 describe("convenience functions", () => {
-  it("isAgent should identify agent environments", () => {
+  it("isAgent identifies agent environments", () => {
     expect(isAgent({ env: { CLAUDECODE: "true" } })).toBe(true);
     expect(isAgent({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(false);
     expect(
@@ -423,34 +522,39 @@ describe("convenience functions", () => {
     ).toBe(true);
   });
 
-  it("isInteractive should identify interactive environments", () => {
+  it("isInteractive identifies interactive environments", () => {
     expect(isInteractive({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(true);
   });
 
-  it("isHybrid should identify hybrid environments", () => {
+  it("isHybrid identifies hybrid environments", () => {
     expect(isHybrid({ env: { TERM_PROGRAM: "WarpTerminal" } })).toBe(true);
     expect(isHybrid({ env: { CLAUDECODE: "true" } })).toBe(false);
     expect(isHybrid({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(false);
+  });
+
+  it("isProvider matches by name", () => {
+    expect(isProvider("Claude Code", { env: { CLAUDECODE: "1" } })).toBe(true);
+    expect(isProvider("Cursor", { env: { CLAUDECODE: "1" } })).toBe(false);
   });
 });
 
 describe("legacy positional API (deprecated)", () => {
   // These call shapes are kept working for backwards compatibility with
   // callers from before the options-object signature landed.
-  it("should accept (env) positional", () => {
+  it("accepts (env) positional", () => {
     const result = detectAgenticEnvironment({ CLAUDECODE: "true" } as any);
-    expect(result.id).toBe("claude-code");
+    expect(result.agent?.id).toBe("claude-code");
   });
 
-  it("should accept (env, processAncestry) positional and treat ancestry as opt-in", () => {
+  it("accepts (env, processAncestry) positional and treats ancestry as opt-in", () => {
     const result = detectAgenticEnvironment(
       {} as any,
       [{ command: "octofriend" }],
     );
-    expect(result.id).toBe("octofriend");
+    expect(result.agent?.id).toBe("octofriend");
   });
 
-  it("should not consult processAncestry under the legacy (env) one-arg form", () => {
+  it("does not consult processAncestry under the legacy (env) one-arg form", () => {
     // No second arg means no opt-in; ancestry isn't consulted.
     const result = detectAgenticEnvironment({} as any);
     expect(result.isAgentic).toBe(false);


### PR DESCRIPTION
## Summary

`am-i-vibing` today answers "is an AI agent driving this command?" with a single identity. But callers increasingly want two further things: which version of the agent and what session it belongs to, and where the process is running – cloud sandbox, CI runner, IDE, or WebContainer. They have to derive these from `process.env` themselves.

This PR splits the detection result into two independent halves – `agent` and `environment` – and surfaces version, session, container, and run identifiers where the underlying tools actually expose them.

## What changed

- New `EnvironmentInfo` concept alongside `AgentInfo`. The detector runs two passes: which AI is driving the process, and where the process is running. Either can be `null`.
- `agent.version` and `agent.sessionId` populated for Claude Code, Codex CLI, and Cursor.
- `environment.containerId` and `environment.runId` populated for Claude Code Cloud, GitHub Actions, GitLab CI, CircleCI, Buildkite, and Replit.
- New environment matchers: Claude Code Cloud, GitHub Actions, GitLab CI, CircleCI, Buildkite, Replit, Jules, WebContainer, VS Code, Cursor (as IDE), Zed (as IDE).
- New exports: `detectAgent`, `detectEnvironment`, `environments`, `getEnvironment`, `getEnvironmentsByKind`, plus the new types.
- Configuration stays declarative. Providers and environments declare `versionEnvVar`, `sessionIdEnvVar`, `containerIdEnvVar`, `runIdEnvVar` as `string | string[]` (first non-empty value wins).

## New API shape

```ts
interface DetectionResult {
  isAgentic: boolean;             // True iff agent !== null
  agent: AgentInfo | null;
  environment: EnvironmentInfo | null;
}

interface AgentInfo {
  id: string;
  name: string;
  type: "agent" | "interactive" | "hybrid";
  version?: string;
  sessionId?: string;
}

interface EnvironmentInfo {
  id: string;
  name: string;
  kind: "cloud-sandbox" | "ci-runner" | "ide" | "webcontainer";
  containerId?: string;
  runId?: string;
}
```

The two halves are populated independently. A CI job with no AI agent gets `agent: null` and a populated `environment`. Claude Code on a developer's laptop gets the agent populated and `environment: null` – we know it isn't a recognised cloud, CI, or IDE environment; we don't claim to know it definitely is "local".

## Recommended usage pattern

We recommend consumers **destructure** the fields they use rather than treat the result object as opaque:

```ts
// Recommended
const { agent, environment } = detectAgenticEnvironment();

// Avoid – breaks if we add new top-level fields later
function logResult(result: DetectionResult) { /* … */ }
```

We may add further top-level fields in future versions (host / network / billing-org identifiers are plausible candidates). Destructuring keeps consumer code forward-compatible with those additions. The `DetectionResult` interface carries the same guidance via TSDoc so it surfaces in IDE autocomplete.

## Worked example: instrumenting an app for observability

A common reason callers reach for `am-i-vibing` is to tag analytics or log events with attribution metadata – who is running this, in what conversation, on what infrastructure.

**Before**

```ts
import { detectAgenticEnvironment } from "am-i-vibing";

function tagEvent(name: string, props: Record<string, unknown>) {
  const result = detectAgenticEnvironment();
  return {
    event: name,
    properties: {
      ...props,
      agent_name: result.name,                  // "Claude Code" or null
      // No agent version, no session id – you'd have to read
      // process.env.CLAUDE_CODE_VERSION yourself, and know to look there.
      // No idea whether we're in a cloud sandbox vs CI vs an IDE either.
      ci: Boolean(process.env.CI),
      ci_run_id: process.env.GITHUB_RUN_ID
              ?? process.env.CI_JOB_ID
              ?? process.env.CIRCLE_BUILD_NUM,
    },
  };
}
```

The caller knows the agent's name and not much else. Anything richer means hand-rolling a parallel pile of `process.env` lookups – the exact thing this library exists to centralise.

**After**

```ts
import { detectAgenticEnvironment } from "am-i-vibing";

function tagEvent(name: string, props: Record<string, unknown>) {
  const { agent, environment } = detectAgenticEnvironment();
  return {
    event: name,
    properties: {
      ...props,
      agent_id: agent?.id,
      agent_version: agent?.version,
      agent_session_id: agent?.sessionId,
      environment_id: environment?.id,
      environment_kind: environment?.kind,
      environment_container_id: environment?.containerId,
      environment_run_id: environment?.runId,
    },
  };
}
```

Same call, three concrete wins for the consumer:

- **Trace within an AI conversation.** `agent_session_id` is stable for the life of one Claude Code / Codex / Cursor session, so events from the same conversation can be grouped without correlating against logs.
- **Track adoption per agent version.** `agent_version` lets you slice usage by Claude Code release without telling users to set anything.
- **Classify the runtime without a second library.** `environment_kind` answers "cloud sandbox vs CI vs IDE" once, instead of unioning provider-specific env-var checks. A CI-only run with no AI agent still populates `environment`, so the same code path tags both cases consistently.

## Coverage

What gets returned in real-world combinations:

| Scenario | agent.id | .version | .sessionId | environment.id | .containerId | .runId |
|---|---|---|---|---|---|---|
| Claude Code on laptop | claude-code | ✓ | ✓ | null | · | · |
| Claude Code Cloud | claude-code | ✓ | ✓ | claude-code-cloud | ✓ | – |
| Claude Code in GitHub Actions | claude-code | ✓ | ✓ | github-actions | ✓ | ✓ |
| Codex CLI on laptop | codex | – | ✓ | null | · | · |
| Cursor Agent on laptop | cursor-agent | – | ✓ | null | · | · |
| Replit Assistant | replit-assistant | – | – | replit-cloud | ✓ | – |
| Aider in GitHub Actions | aider | – | – | github-actions | ✓ | ✓ |
| Bolt.new Agent | bolt-agent | – | – | webcontainer | – | – |
| CI job, no AI agent | null | · | · | github-actions | ✓ | ✓ |

## Why this shape

We surveyed the env vars exposed by the major coding agents before settling on the design. Three findings drove the decisions:

1. **Stable session IDs only exist on a handful of agents today**: Claude Code, Codex CLI, Cursor, Replit (where `REPL_ID` does double duty), and GitHub Actions. The matrix is sparse, which is why every new field is optional rather than required – we'd otherwise be forced to fabricate data.
2. **"Cloud vs local" is rarely a single env var.** It's usually inferred from "agent X is running AND we see container fingerprints Y" – so environment detection needs its own matchers, not a flag bolted onto each provider.
3. **Claude Code's binary defines a closed enum of ten entrypoints** (cli, remote, remote_desktop, sdk-ts, sdk-py, sdk-cli, local-agent, mcp, claude-code-github-action, claude-vscode, claude-desktop). We didn't ship that verbatim – instead the environment is inferred from independent signals like `CLAUDE_CODE_REMOTE` and `GITHUB_ACTIONS`, which composes cleanly with non-Claude environments.

## Migration (breaking change)

Top-level `id`, `name`, and `type` move under `agent`:

```ts
// before
result.id            // "claude-code"
result.name          // "Claude Code"
result.type          // "agent"

// after
result.agent?.id     // "claude-code"
result.agent?.name   // "Claude Code"
result.agent?.type   // "agent"
```

`isAgentic` is unchanged in meaning (true when an agent is detected). `--format json` output changes shape. The CLI exit-code contract is unchanged: `0` if an agent is detected, `1` otherwise. The `--check` and `--quiet` flags still operate on the agent half only, so existing scripts using them keep working.

The convenience helpers (`isAgent`, `isInteractive`, `isHybrid`, `isProvider`) keep their signatures and behaviour.

## Alternative considered: keep `detectAgenticEnvironment` flat (non-breaking)

If we'd rather not break the existing API at this stage, the change can be repackaged so nothing existing moves:

```ts
// Unchanged – keeps returning the flat shape today's callers expect
export function detectAgenticEnvironment(): {
  isAgentic: boolean;
  id: string | null;
  name: string | null;
  type: AgenticType | null;
};

// New – the nested shape this PR currently puts under detectAgenticEnvironment
export function detectFullAgenticEnvironment(): DetectionResult;
```

`detectAgent` and `detectEnvironment` are already non-breaking (they're brand-new exports) and would stay as is. The two-pass detector machinery is internal, so existing consumers keep their flat result, opt-in callers get the richer nested one, and we ship a patch/minor instead of a minor-with-migration.

The trade-off:

- **Pro**: zero breakage for anyone already using the library; existing scripts and `--format json` output are untouched.
- **Pro**: lets the new shape settle before we force a migration, so we can iterate on field names without making people migrate twice.
- **Con**: two ways to ask the same question. `detectAgenticEnvironment` returns a worse-than-default shape that we'd want to deprecate eventually – the migration is deferred, not avoided.
- **Con**: the CLI surface gets muddier. We'd either keep `--format json` flat (and add something like `--format json-full`) or break it anyway.
- **Con**: the better API ends up with the longer, second-class name. `detectFullAgenticEnvironment` is bikeshed-friendly; alternatives include `detect()`, `inspect()`, or just exposing `detectAgent` + `detectEnvironment` and letting callers compose.

My lean is to take the breaking change now while we're at 0.x and adoption is still small – it's the moment with the lowest migration cost. But the non-breaking variant is a reasonable call if you'd rather defer that hit.

## Out of scope

- **Codex Cloud**: no env-var fingerprint we could verify from primary sources. Documented as a gap; additive when one is confirmed.
- **Cursor Background Agent**: runs on a remote VM but doesn't currently set a documented `CURSOR_BACKGROUND`-style flag. Same deal.
- **Devin / JetBrains AI Assistant / Junie**: no public env-var contract we could verify.
- **Refactoring existing `replit` / `jules` providers**: they still match the same conditions they always did. Splitting them into pure agent vs environment matchers can be a follow-up if useful.

## Test plan

- [x] All 55 unit tests pass: existing assertions ported to nested shape, plus new coverage for environment detection, version/session/container/run extraction, and combined agent + environment scenarios.
- [x] Type check passes (`tsc --noEmit`).
- [x] Build succeeds (`pnpm run build`).
- [ ] CLI smoke-tested in synthetic environments for: laptop with no agent, Claude Code on laptop, Claude Code Cloud, Claude Code on GitHub Actions, CI runner with no agent, JSON output.
- [x] Changeset added (minor bump, breaking change documented).

## Notes for reviewers

- The two-pass detector keeps the matcher logic identical for both halves – `matches()` runs against either a `ProviderConfig` or `EnvironmentConfig`, only the result-construction differs. Adding a third axis later (e.g. host-OS sandboxing) would follow the same shape: one new config file, one new info type, one more pass in `detectAgenticEnvironment`.
- `EnvironmentConfig` keeps `processChecks` and `customDetectors` fields even though no shipped environment uses them today. They're there for future cases like Codex Cloud, where the only fingerprint we could find is the `codex-universal` container image.
- `--check` and `--quiet` deliberately stay scoped to agents. They're the script-friendly contracts existing users may already depend on; widening them silently to include environments would be a behaviour change with no opt-in. A future `--check ci` style flag is the natural extension.