### PR TITLE
feat: detect Pi coding agent

### DIFF
--- a/.changeset/detect-pi-agent.md
+++ b/.changeset/detect-pi-agent.md
@@ -1,0 +1,5 @@
+---
+"am-i-vibing": minor
+---
+
+Add detection for the Pi coding agent (earendil-works/pi) via the `PI_CODING_AGENT=true` environment variable it sets on startup.

--- a/packages/am-i-vibing/README.md
+++ b/packages/am-i-vibing/README.md
@@ -35,6 +35,7 @@ console.log(`Detected: ${result.name} (${result.type})`);
 - **Jules**
 - **Octofriend** (process detection only — requires `checkProcesses`)
 - **opencode**
+- **Pi**
 - **Replit**
 - **Warp**
 - **Windsurf**

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -266,6 +266,16 @@ export const providers: ProviderConfig[] = [
     // is the only reliable signal, so detection is opt-in via processAncestry.
     processChecks: ["droid"],
   },
+  {
+    id: "pi",
+    name: "Pi",
+    type: "agent",
+    // Pi's CLI entry point sets PI_CODING_AGENT=true on startup, and its bash tool
+    // passes the process env through to every command it runs (getShellEnv spreads
+    // ...process.env), so the variable is inherited by spawned shells.
+    // See: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/cli.ts
+    envVars: [["PI_CODING_AGENT", "true"]],
+  },
 ];
 
 /**

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -33,6 +33,26 @@ describe("detectAgenticEnvironment", () => {
     expect(result.type).toBe("agent");
   });
 
+  it("should detect Pi environment", () => {
+    const result = detectAgenticEnvironment({
+      env: { PI_CODING_AGENT: "true" },
+    });
+
+    expect(result.isAgentic).toBe(true);
+    expect(result.id).toBe("pi");
+    expect(result.name).toBe("Pi");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should not detect Pi when PI_CODING_AGENT has the wrong value", () => {
+    const result = detectAgenticEnvironment({
+      env: { PI_CODING_AGENT: "false" },
+    });
+
+    expect(result.isAgentic).toBe(false);
+    expect(result.id).toBe(null);
+  });
+
   it("should detect Cursor environment", () => {
     const result = detectAgenticEnvironment({
       env: { CURSOR_TRACE_ID: "cursor-trace-123" },


### PR DESCRIPTION
Adds detection for the Pi coding agent (`earendil-works/pi`).

Pi sets `PI_CODING_AGENT=true` on startup and passes its environment through to commands it runs, so that variable is a reliable signal. Detected as an `agent`.

Includes a positive test, a negative test for an unexpected value, and a changeset.