### PR TITLE
feat: detect Warp agent via OZ_RUN_ID

### DIFF
--- a/.changeset/warp-agent-detection.md
+++ b/.changeset/warp-agent-detection.md
@@ -1,0 +1,7 @@
+---
+"am-i-vibing": minor
+---
+
+Detect Warp's agent via the `OZ_RUN_ID` environment variable it sets while running an agent task, and report it as an `agent` rather than a `hybrid` environment.
+
+Previously Warp was detected from `TERM_PROGRAM=WarpTerminal`, which is set in every Warp window whether or not its agent is active. That produced false positives for people using Warp as a regular terminal (e.g. running `astro dev` by hand). Plain Warp sessions are no longer detected; only commands run under Warp's agent are.

--- a/packages/am-i-vibing/README.md
+++ b/packages/am-i-vibing/README.md
@@ -71,7 +71,7 @@ The library detects three main types of environments:
 
 - **Agent**: Command was directly run by an AI agent (e.g. Claude Code, Codex CLI, Jules)
 - **Interactive**: Interactive commands run inside an AI environment (e.g. Cursor terminal, Replit shell)
-- **Hybrid**: Environments that combine both agentic and interactive features in the same session (e.g. Warp)
+- **Hybrid**: Environments that combine both agentic and interactive features in the same session
 
 There may be false positives, such as if a user directly runs a command in an terminal opened by an AI tool, such as a Copilot terminal in VS Code.
 

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -230,13 +230,13 @@ export const providers: ProviderConfig[] = [
   },
   {
     id: "warp",
-    name: "Warp Terminal",
-    type: "hybrid",
-    envVars: [
-      {
-        all: [["TERM_PROGRAM", "WarpTerminal"]],
-      },
-    ],
+    name: "Warp",
+    type: "agent",
+    // Warp's agent ("Oz") sets OZ_RUN_ID for commands it runs and reads it back
+    // to detect it is inside an agent run. TERM_PROGRAM=WarpTerminal is set in
+    // every Warp window, agent or not, so it is not a usable agent signal.
+    // https://github.com/warpdotdev/warp/blob/master/crates/warp_cli/src/lib.rs
+    envVars: [["OZ_RUN_ID"]],
   },
   {
     id: "octofriend",

--- a/packages/am-i-vibing/src/providers.ts
+++ b/packages/am-i-vibing/src/providers.ts
@@ -233,8 +233,7 @@ export const providers: ProviderConfig[] = [
     name: "Warp",
     type: "agent",
     // Warp's agent ("Oz") sets OZ_RUN_ID for commands it runs and reads it back
-    // to detect it is inside an agent run. TERM_PROGRAM=WarpTerminal is set in
-    // every Warp window, agent or not, so it is not a usable agent signal.
+    // to detect it is inside an agent run.
     // https://github.com/warpdotdev/warp/blob/master/crates/warp_cli/src/lib.rs
     envVars: [["OZ_RUN_ID"]],
   },

--- a/packages/am-i-vibing/test/detector.test.ts
+++ b/packages/am-i-vibing/test/detector.test.ts
@@ -178,15 +178,24 @@ describe("detectAgenticEnvironment", () => {
     expect(result.type).toBe("interactive");
   });
 
-  it("should detect Warp hybrid environment", () => {
+  it("should detect Warp agent environment via OZ_RUN_ID", () => {
     const result = detectAgenticEnvironment({
-      env: { TERM_PROGRAM: "WarpTerminal" },
+      env: { OZ_RUN_ID: "run-123" },
     });
 
     expect(result.isAgentic).toBe(true);
     expect(result.id).toBe("warp");
-    expect(result.name).toBe("Warp Terminal");
-    expect(result.type).toBe("hybrid");
+    expect(result.name).toBe("Warp");
+    expect(result.type).toBe("agent");
+  });
+
+  it("should not detect Warp from TERM_PROGRAM alone", () => {
+    const result = detectAgenticEnvironment({
+      env: { TERM_PROGRAM: "WarpTerminal" },
+    });
+
+    expect(result.isAgentic).toBe(false);
+    expect(result.id).toBe(null);
   });
 
   it("should detect Gemini CLI via GEMINI_CLI env var", () => {
@@ -471,8 +480,8 @@ describe("convenience functions", () => {
     expect(isInteractive({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(true);
   });
 
-  it("isHybrid should identify hybrid environments", () => {
-    expect(isHybrid({ env: { TERM_PROGRAM: "WarpTerminal" } })).toBe(true);
+  it("isHybrid should return false when no hybrid provider matches", () => {
+    expect(isHybrid({ env: { OZ_RUN_ID: "run-123" } })).toBe(false);
     expect(isHybrid({ env: { CLAUDECODE: "true" } })).toBe(false);
     expect(isHybrid({ env: { CURSOR_TRACE_ID: "trace-123" } })).toBe(false);
   });

--- a/packages/am-i-vibing/test/hello.test.ts
+++ b/packages/am-i-vibing/test/hello.test.ts
@@ -35,10 +35,10 @@ describe("providers", () => {
     expect(boltAgent?.type).toBe("agent");
   });
 
-  it("should include Warp hybrid provider", () => {
-    const warp = providers.find((p) => p.name === "Warp Terminal");
+  it("should include Warp agent provider", () => {
+    const warp = providers.find((p) => p.name === "Warp");
     expect(warp).toBeDefined();
-    expect(warp?.type).toBe("hybrid");
+    expect(warp?.type).toBe("agent");
   });
 
   it("getProvider should return correct provider", () => {
@@ -57,7 +57,7 @@ describe("providers", () => {
 
     expect(agentProviders.length).toBeGreaterThan(0);
     expect(interactiveProviders.length).toBeGreaterThan(0);
-    expect(hybridProviders.length).toBeGreaterThan(0);
+    expect(hybridProviders.length).toBe(0);
 
     expect(agentProviders.every((p) => p.type === "agent")).toBe(true);
     expect(interactiveProviders.every((p) => p.type === "interactive")).toBe(


### PR DESCRIPTION
Fixes #89.

## Problem

Warp was detected from `TERM_PROGRAM=WarpTerminal`, which Warp sets in **every** window whether or not its agent is active. Running `astro dev` by hand in Warp therefore tripped detection (reported as a `hybrid` environment), causing tools like Astro to switch into agent/background mode for an ordinary interactive session.

The `hybrid` entry only ever existed because, at the time it was added, there was no way to detect Warp's *actual* agent. There now is.

## Change

Warp's agent ("Oz") sets `OZ_RUN_ID` for the commands it runs, and reads it back to detect it is inside an agent run (verified in Warp's now-open-source code: [`warp_cli/src/lib.rs`](https://github.com/warpdotdev/warp/blob/master/crates/warp_cli/src/lib.rs), applied in [`agent_sdk/driver/harness/mod.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/ai/agent_sdk/driver/harness/mod.rs), read back in [`agent_sdk/ambient.rs`](https://github.com/warpdotdev/warp/blob/master/app/src/ai/agent_sdk/ambient.rs)).

So this PR:

- Detects Warp via `OZ_RUN_ID` and reports it as `type: "agent"` (was `"hybrid"` via `TERM_PROGRAM`).
- Renames the provider `name` from `"Warp Terminal"` to `"Warp"` (id stays `warp`).
- Plain Warp sessions are no longer detected at all — only commands run under its agent.

When Warp orchestrates a third-party harness (Claude Code, Codex, Gemini, opencode), that harness still sets its own signal and is detected as itself (it appears earlier in the provider list), so this only claims the native-agent case.

## Notes

- There are no `hybrid` providers left after this. The `hybrid` type and `isHybrid()` remain in the API; tests updated accordingly.
- Verified end-to-end: `OZ_RUN_ID` set → `{"id":"warp","type":"agent"}`; `TERM_PROGRAM=WarpTerminal` alone → not detected.