### PR TITLE
Lazily load process-ancestry for opt-in process checks

### DIFF
--- a/.changeset/lazy-process-ancestry.md
+++ b/.changeset/lazy-process-ancestry.md
@@ -1,0 +1,5 @@
+---
+"am-i-vibing": patch
+---
+
+Load `process-ancestry` only when opt-in process-tree detection is requested, so environment-only detection can be imported in runtimes without Node builtins.

--- a/packages/am-i-vibing/src/detector.ts
+++ b/packages/am-i-vibing/src/detector.ts
@@ -6,7 +6,20 @@ import type {
   EnvVarGroup,
 } from "./types.js";
 import { providers } from "./providers.js";
-import { getProcessAncestry } from "process-ancestry";
+
+// Loaded on demand so importing this package never requires Node's module graph.
+function getProcessAncestry(): Array<{ command?: string }> {
+  try {
+    const nodeModule = globalThis.process?.getBuiltinModule?.("module");
+    if (!nodeModule) {
+      return [];
+    }
+    const requireFromHere = nodeModule.createRequire(import.meta.url);
+    return requireFromHere("process-ancestry").getProcessAncestry();
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Check if a specific environment variable exists (handles both strings and tuples)

--- a/packages/am-i-vibing/test/lazy-process-ancestry.test.ts
+++ b/packages/am-i-vibing/test/lazy-process-ancestry.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("process-ancestry", () => {
+  throw new Error("process-ancestry was loaded statically");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("process-ancestry loading", () => {
+  it("does not load process-ancestry for environment-only detection", async () => {
+    const getBuiltinModule = vi.spyOn(process, "getBuiltinModule");
+    const { detectAgenticEnvironment } = await import("../src/detector.js");
+
+    const result = detectAgenticEnvironment({ env: { CLAUDECODE: "true" } });
+
+    expect(result.id).toBe("claude-code");
+    expect(getBuiltinModule).not.toHaveBeenCalled();
+  });
+
+  it("loads process-ancestry when process checking is requested", async () => {
+    const require = vi.fn(() => ({
+      getProcessAncestry: () => [{ command: "octofriend-cli" }],
+    }));
+    const getBuiltinModule = vi
+      .spyOn(process, "getBuiltinModule")
+      .mockReturnValue({ createRequire: () => require } as never);
+    const { detectAgenticEnvironment } = await import("../src/detector.js");
+
+    const result = detectAgenticEnvironment({ env: {}, checkProcesses: true });
+
+    expect(result.id).toBe("octofriend");
+    expect(getBuiltinModule).toHaveBeenCalledWith("module");
+    expect(require).toHaveBeenCalledWith("process-ancestry");
+  });
+});


### PR DESCRIPTION
TLDR: importing am-i-vibing currently pulls in process-ancestry (and with it Node's child_process) even if you only use env detection. I want to use this package in build time and runtime agnostic contexts (Bun, Deno, edge bundlers), so this PR makes that import lazy.

What changed:

- process-ancestry only loads at the moment process checking is actually requested
- the lazy load uses process.getBuiltinModule("module") to reach require from ESM. On runtimes that don't have it, detection just acts like no process info is available instead of crashing at import
- public API is unchanged and still sync. If you pass your own ancestry data the dependency never loads at all
- one caveat: automatic process checking now needs Node 20.16 / 22.3+ (when getBuiltinModule landed). Env-only detection has no Node requirement at all

Testing: full suite passes (56 tests), plus new tests for env-only detection with the dependency never loaded, and for opt-in process checks on Node. Build, publint, and attw are clean. Patch changeset included.

Also validated the built package directly: the bundle has no static process-ancestry import, env detection works on Node, Bun, and Deno, process checking still works on Node and Bun (both have getBuiltinModule), and a runtime without it degrades to "no ancestry" instead of crashing at import.
